### PR TITLE
Feature: ERC721A Implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@nomiclabs/hardhat-waffle": "^2.0.2",
     "@openzeppelin/contracts": "^4.4.2",
     "chai": "^4.3.6",
+    "erc721a": "^3.2.0",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.4",
     "hardhat": "^2.8.3",

--- a/test/OpenFormat.js
+++ b/test/OpenFormat.js
@@ -532,13 +532,18 @@ describe("Open Format", function () {
       );
 
       // mint NFT
-      await factoryContract["mint(address)"](address2.address, {
+      await factoryContract["mint()"]({
         value,
       });
 
       // Set Token Sale Price
       await factoryContract.setTokenSalePrice(0, value);
 
+      // Give factoryContract approval to transfer
+      await factoryContract.approve(factoryContract.address, 0);
+
+      console.log("approved", await factoryContract.getApproved(0));
+      console.log("FC", factoryContract.address);
       // Buy
       await factoryContract
         .connect(address1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2867,6 +2867,13 @@ env-paths@^2.2.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
+erc721a@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/erc721a/-/erc721a-3.2.0.tgz#5f2ba2599465fbd51088b4d9d7c3e0ba340daa5e"
+  integrity sha512-bK6rT45M8csSpH/8SBAhlmyIlCh0LrejflvkSw9zVPU5pNRSe0P0YWmv/g6seYwc8OCfL9ND/fKL8LsuvuePmg==
+  dependencies:
+    "@openzeppelin/contracts" "^4.4.2"
+
 errno@~0.1.1:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.8.tgz#8bb3e9c7d463be4976ff888f76b4809ebc2e811f"


### PR DESCRIPTION
**WIP** - Use [ERC721A](https://chiru-labs.github.io/ERC721A/#/) instead of OpenZeppelin's [ERC721](https://docs.openzeppelin.com/contracts/4.x/api/token/erc721).