### PR TITLE
Feature: Update error codes

### DIFF
--- a/contracts/OpenFormat.sol
+++ b/contracts/OpenFormat.sol
@@ -456,7 +456,7 @@ contract OpenFormat is
     }
 
     modifier onlyTokenOwnerOrApproved(uint256 tokenId) {
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "WOF:E-010");
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "OF:E-010");
         _;
     }
 }

--- a/contracts/OpenFormat.sol
+++ b/contracts/OpenFormat.sol
@@ -138,7 +138,7 @@ contract OpenFormat is
         whenNotPaused
         returns (uint256 newTokenId)
     {
-        require(msg.value >= mintingPrice, "WL:E-001");
+        require(msg.value >= mintingPrice, "OF:E-001");
 
         newTokenId = _mint();
     }
@@ -151,7 +151,7 @@ contract OpenFormat is
         whenNotPaused
         returns (uint256 newTokenId)
     {
-        require(msg.value >= mintingPrice, "WL:E-001");
+        require(msg.value >= mintingPrice, "OF:E-001");
 
         if (primaryCommissionPct > 0) {
             uint256 amount = _calculatePercentage(
@@ -181,7 +181,7 @@ contract OpenFormat is
         override
         returns (bool)
     {
-        require(commissionAddress != address(0), "WL-009");
+        require(commissionAddress != address(0), "OF:E-002");
         uint256 tokenSalePrice = _tokenSalePrice[tokenId];
         uint256 commissionAmount = _calculatePercentage(
             secondaryCommissionPct,
@@ -201,7 +201,7 @@ contract OpenFormat is
         virtual
         override
     {
-        require(contractAddress == approvedDepositExtension, "Not approved");
+        require(contractAddress == approvedDepositExtension, "OF:E-003");
 
         uint256 total = totalSupply();
 
@@ -222,8 +222,8 @@ contract OpenFormat is
         uint256 allowance = token.allowance(msg.sender, address(this));
         uint256 total = totalSupply();
 
-        require(contractAddress == approvedDepositExtension, "Not approved");
-        require(allowance >= amount, "Check the token allowance");
+        require(contractAddress == approvedDepositExtension, "OF:E-003");
+        require(allowance >= amount, "OF:E-004");
 
         token.transferFrom(msg.sender, address(this), amount);
 
@@ -242,7 +242,7 @@ contract OpenFormat is
         payable
         returns (uint256)
     {
-        require(contractAddress == approvedDepositExtension, "Not approved");
+        require(contractAddress == approvedDepositExtension, "OF:E-003");
 
         address owner = ownerOf(tokenId); // 0
         uint256 amount = IDepositManager(approvedDepositExtension)
@@ -261,7 +261,7 @@ contract OpenFormat is
         address contractAddress,
         uint256 tokenId
     ) public payable returns (uint256) {
-        require(contractAddress == approvedDepositExtension, "Not approved");
+        require(contractAddress == approvedDepositExtension, "OF:E-003");
 
         address owner = ownerOf(tokenId); // 0
         uint256 amount = IDepositManager(approvedDepositExtension)
@@ -302,7 +302,7 @@ contract OpenFormat is
         override
         onlyOwner
     {
-        require(_royaltiesPct > 0, "Royalties must be greater than 0");
+        require(_royaltiesPct > 0, "OF:E-004");
         require(royaltyReceiver != address(0), "OF:E-005");
 
         _setRoyalties(royaltyReceiver, _royaltiesPct);
@@ -346,18 +346,18 @@ contract OpenFormat is
         external
         onlyOwner
     {
-        require(amount_ <= PERCENTAGE_SCALE, "WP-010");
-        require(approvedRoyaltyExtension != address(0), "OF:E-001");
+        require(amount_ <= PERCENTAGE_SCALE, "OF:E-006");
+        require(approvedRoyaltyExtension != address(0), "OF:E-007");
         IRoyaltyManager(approvedRoyaltyExtension).setCustomRoyaltyPct(amount_);
     }
 
     function setPrimaryCommissionPct(uint256 amount_) public onlyOwner {
-        require(amount_ <= PERCENTAGE_SCALE, "WP-008");
+        require(amount_ <= PERCENTAGE_SCALE, "OF:E-006");
         primaryCommissionPct = amount_;
     }
 
     function setSecondaryCommissionPct(uint256 amount_) public onlyOwner {
-        require(amount_ <= PERCENTAGE_SCALE, "WP-009");
+        require(amount_ <= PERCENTAGE_SCALE, "OF:E-006");
         secondaryCommissionPct = amount_;
     }
 
@@ -379,8 +379,8 @@ contract OpenFormat is
         returns (bool)
     {
         uint256 tokenSalePrice = _tokenSalePrice[tokenId];
-        require(tokenSalePrice > 0, "WL:E-002");
-        require(value >= tokenSalePrice, "WL:E-003");
+        require(tokenSalePrice > 0, "OF:E-007");
+        require(value >= tokenSalePrice, "OF:E-008");
 
         address oldOwner = ownerOf(tokenId);
         address newOwner = _msgSender();
@@ -451,12 +451,12 @@ contract OpenFormat is
   |__________________________________*/
 
     modifier whenNotPaused() {
-        require(!paused, "WL:E-004");
+        require(!paused, "OF:E-009");
         _;
     }
 
     modifier onlyTokenOwnerOrApproved(uint256 tokenId) {
-        require(_isApprovedOrOwner(_msgSender(), tokenId), "WL:E-005");
+        require(_isApprovedOrOwner(_msgSender(), tokenId), "WOF:E-010");
         _;
     }
 }

--- a/contracts/PaymentSplitter.sol
+++ b/contracts/PaymentSplitter.sol
@@ -232,7 +232,7 @@ contract PaymentSplitter is Context {
     function allocateShares(address account, uint256 shares_) external {
         require(
             _shares[msg.sender] > shares_,
-            "You dont have enough shares to give away"
+            "PaymentSplitter: account does not have enough shares to allocate"
         );
 
         _shares[msg.sender] = _shares[msg.sender] - shares_;

--- a/contracts/extensions/DepositExtension.sol
+++ b/contracts/extensions/DepositExtension.sol
@@ -96,10 +96,7 @@ contract DepositExtension {
     }
 
     modifier onlyApprovedCaller() {
-        require(
-            _approvedCallers[msg.sender],
-            "Only approved caller can call this function"
-        );
+        require(_approvedCallers[msg.sender], "DE:E-001");
         _;
     }
 }

--- a/contracts/extensions/RoyaltyExtension.sol
+++ b/contracts/extensions/RoyaltyExtension.sol
@@ -25,12 +25,14 @@ contract RoyaltiesExtension is IRoyaltyManager {
     }
 
     receive() external payable {
-        require(customRoyaltyPcts[msg.sender] > 0, "customRoyaltyPct not set");
+        require(customRoyaltyPcts[msg.sender] > 0, "RE:E-001");
 
         uint256 amount = uint256(msg.value)
             .mul(customRoyaltyPcts[msg.sender])
             .div(PERCENTAGE_SCALE);
-        IOpenFormat(msg.sender).deposit{value: amount}(approvedDepositExtension);
+        IOpenFormat(msg.sender).deposit{value: amount}(
+            approvedDepositExtension
+        );
 
         payable(msg.sender).sendValue(msg.value.sub(amount));
     }

--- a/test/DepositExtension.js
+++ b/test/DepositExtension.js
@@ -186,17 +186,13 @@ describe("DepositExtension", function () {
     const amount = "1000000000000000000";
     await expect(
       revShare.calculateSplitETH(amount, 5)
-    ).to.be.revertedWith(
-      "Only approved caller can call this function"
-    );
+    ).to.be.revertedWith("DE:E-001");
   });
 
   it("should only let approvedCaller call updateSplitBalance()", async () => {
     const amount = "1000000000000000000";
     await expect(
       revShare.calculateSplitETH(amount, 0)
-    ).to.be.revertedWith(
-      "Only approved caller can call this function"
-    );
+    ).to.be.revertedWith("DE:E-001");
   });
 });

--- a/test/OpenFormat.js
+++ b/test/OpenFormat.js
@@ -462,7 +462,9 @@ describe("Open Format", function () {
       factoryContract
         .connect(owner)
         .allocateShares(address1.address, 101)
-    ).to.be.revertedWith("You dont have enough shares to give away");
+    ).to.be.revertedWith(
+      "PaymentSplitter: account does not have enough shares to allocate"
+    );
   });
   describe("Sales commission", function () {
     it("should allow the owner to set the sales commission", async () => {
@@ -475,7 +477,7 @@ describe("Open Format", function () {
     it("should prevent from setting a sales commission over 100%", async () => {
       await expect(
         factoryContract.setPrimaryCommissionPct(10001)
-      ).to.be.revertedWith("WP-008");
+      ).to.be.revertedWith("OF:E-006");
     });
 
     it("shoud prevent anyone to set sales commission", async () => {

--- a/test/RoyaltyExtension.js
+++ b/test/RoyaltyExtension.js
@@ -98,7 +98,7 @@ describe("RoyaltiesExtension", function () {
   it("should revert if royaltyManager is not set", async () => {
     await expect(
       factoryContract.setApprovedRoyaltyExtensionCustomPct(holdersPct)
-    ).to.be.revertedWith("OF:E-001");
+    ).to.be.revertedWith("OF:E-007");
   });
 
   it("should not use royaltyManager if not set", async () => {


### PR DESCRIPTION
| Code  | Error |
| ------------- | ------------- |
| OF:E-001  | The value sent is less than the minting price  |
| OF:E-002  | The commission address passed to the function is invalid  |
| OF:E-003  | The address passed to the function does not match the approved deposit extension address  |
| OF:E-004 | Allowance is less than the deposit amount  |
| OF:E-005  | The royalty receiver address passed to the function is invalid  |
| OF:E-006  | The amount must be less than or equal to 10000 (100%)  |
| OF:E-007  | The approved royalty extension address has not been set or is invalid |
| OF:E-008  | The value sent is less than the token sale price  |
| OF:E-009  | Paused state is true  |
| OF:E-010  | sender must be token owner or approved  |

| Code  | Error |
| ------------- | ------------- |
| DE:E-001  | Only approved callers can call this function |

| Code  | Error |
| ------------- | ------------- |
| RE:E-001  | Custom royalty percentage for this address is 0 |