### PR TITLE
Feature: Remove unnecessary `contractAddress` param from deposit and withdraw functions

### DIFF
--- a/contracts/OpenFormat.sol
+++ b/contracts/OpenFormat.sol
@@ -256,12 +256,8 @@ contract OpenFormat is
         emit ERC20TotalDepositedAmountUpdated(token, msg.value);
     }
 
-    function withdraw(address contractAddress, uint256 tokenId)
-        public
-        payable
-        returns (uint256)
-    {
-        require(contractAddress == approvedDepositExtension, "OF:E-003");
+    function withdraw(uint256 tokenId) public payable returns (uint256) {
+        require(approvedDepositExtension != address(0), "OF:E-003");
 
         address owner = ownerOf(tokenId); // 0
         uint256 amount = IDepositManager(approvedDepositExtension)
@@ -277,12 +273,12 @@ contract OpenFormat is
         return amount;
     }
 
-    function withdraw(
-        IERC20 token,
-        address contractAddress,
-        uint256 tokenId
-    ) public payable returns (uint256) {
-        require(contractAddress == approvedDepositExtension, "OF:E-003");
+    function withdraw(IERC20 token, uint256 tokenId)
+        public
+        payable
+        returns (uint256)
+    {
+        require(approvedDepositExtension != address(0), "OF:E-003");
 
         address owner = ownerOf(tokenId); // 0
         uint256 amount = IDepositManager(approvedDepositExtension)

--- a/contracts/OpenFormat.sol
+++ b/contracts/OpenFormat.sol
@@ -215,13 +215,8 @@ contract OpenFormat is
         return _buy(tokenId, uint256(msg.value).sub(commissionAmount));
     }
 
-    function deposit(address contractAddress)
-        external
-        payable
-        virtual
-        override
-    {
-        require(contractAddress == approvedDepositExtension, "OF:E-003");
+    function deposit() external payable virtual override {
+        require(approvedDepositExtension != address(0), "OF:E-003");
 
         uint256 total = totalSupply();
 
@@ -236,15 +231,16 @@ contract OpenFormat is
         emit TotalDepositedAmountUpdated(msg.value);
     }
 
-    function deposit(
-        address contractAddress,
-        IERC20 token,
-        uint256 amount
-    ) external payable virtual override {
+    function deposit(IERC20 token, uint256 amount)
+        external
+        payable
+        virtual
+        override
+    {
         uint256 allowance = token.allowance(msg.sender, address(this));
         uint256 total = totalSupply();
 
-        require(contractAddress == approvedDepositExtension, "OF:E-003");
+        require(approvedDepositExtension != address(0), "OF:E-003");
         require(allowance >= amount, "OF:E-004");
 
         token.transferFrom(msg.sender, address(this), amount);

--- a/contracts/extensions/RoyaltyExtension.sol
+++ b/contracts/extensions/RoyaltyExtension.sol
@@ -41,9 +41,7 @@ contract RoyaltiesExtension is IRoyaltyManager {
             .mul(totalSupply);
 
         // SEND FUNDS TO NFT HOLDERS
-        IOpenFormat(msg.sender).deposit{value: amount}(
-            approvedDepositExtension
-        );
+        IOpenFormat(msg.sender).deposit{value: amount}();
 
         // SEND FUNDS TO COLLABORATORS SPLITS
         payable(msg.sender).sendValue(msg.value.sub(amount));

--- a/contracts/interfaces/IOpenFormat.sol
+++ b/contracts/interfaces/IOpenFormat.sol
@@ -87,13 +87,9 @@ interface IOpenFormat is IERC721 {
 
     function burn(uint256 tokenId) external;
 
-    function deposit(address contractAddress) external payable;
+    function deposit() external payable;
 
-    function deposit(
-        address contractAddress,
-        IERC20 token,
-        uint256 amount
-    ) external payable;
+    function deposit(IERC20 token, uint256 amount) external payable;
 
     function getMaxSupply() external view returns (uint256);
 

--- a/test/DepositExtension.js
+++ b/test/DepositExtension.js
@@ -108,9 +108,7 @@ describe("DepositExtension", function () {
       "getSingleTokenBalance(address,uint256)"
     ](factoryContract.address, 0);
 
-    const withdraw = await factoryContract[
-      "withdraw(address,uint256)"
-    ](revShare.address, 0);
+    const withdraw = await factoryContract["withdraw(uint256)"](0);
 
     // calculate withdraw gas
     const withdrawReceipt = await withdraw.wait();

--- a/test/DepositExtension.js
+++ b/test/DepositExtension.js
@@ -52,14 +52,10 @@ describe("DepositExtension", function () {
       .connect(owner)
       .approve(factoryContract.address, value);
 
-    // deposit ETH
+    // deposit ERC20
     await factoryContract
       .connect(owner)
-      ["deposit(address,address,uint256)"](
-        revShare.address,
-        erc20.address,
-        value
-      );
+      ["deposit(address,uint256)"](erc20.address, value);
 
     const ownerBalance = await revShare[
       "getSingleTokenBalance(address,address,uint256)"
@@ -80,9 +76,7 @@ describe("DepositExtension", function () {
     await factoryContract.connect(address1)["mint()"]({ value });
 
     // deposit ETH
-    await factoryContract
-      .connect(address1)
-      ["deposit(address)"](revShare.address, { value });
+    await factoryContract.connect(address1)["deposit()"]({ value });
 
     const ownerBalance = await revShare[
       "getSingleTokenBalance(address,uint256)"
@@ -108,9 +102,7 @@ describe("DepositExtension", function () {
     const ownerBalance = await owner.getBalance();
 
     // deposit ETH
-    await factoryContract
-      .connect(address1)
-      ["deposit(address)"](revShare.address, { value });
+    await factoryContract.connect(address1)["deposit()"]({ value });
 
     const ownerShares = await revShare[
       "getSingleTokenBalance(address,uint256)"
@@ -139,17 +131,13 @@ describe("DepositExtension", function () {
     // mint one token
     await factoryContract["mint()"]({ value });
     // deposit ETH
-    await factoryContract
-      .connect(address1)
-      ["deposit(address)"](revShare.address, { value });
+    await factoryContract.connect(address1)["deposit()"]({ value });
 
     // mint another token
     await factoryContract.connect(address1)["mint()"]({ value });
 
     // deposit more ETH
-    await factoryContract
-      .connect(address1)
-      ["deposit(address)"](revShare.address, { value });
+    await factoryContract.connect(address1)["deposit()"]({ value });
 
     const newOwnerBalance = await revShare[
       "getSingleTokenBalance(address,uint256)"
@@ -172,12 +160,10 @@ describe("DepositExtension", function () {
     // mint one token
     await factoryContract["mint()"]({ value });
     // deposit ETH
+    await factoryContract.connect(address1)["deposit()"]({ value });
     await factoryContract
       .connect(address1)
-      ["deposit(address)"](revShare.address, { value });
-    await factoryContract
-      .connect(address1)
-      ["deposit(address)"](revShare.address, { value: value2 });
+      ["deposit()"]({ value: value2 });
 
     const totalReceived =
       await factoryContract.totalDepositedAmount();

--- a/test/OpenFormat.js
+++ b/test/OpenFormat.js
@@ -159,10 +159,7 @@ describe("Open Format", function () {
     const contractBalance = await balance(factoryContract.address);
 
     // withdraw revShare for token id 2;
-    await factoryContract["withdraw(address,uint256)"](
-      revShare.address,
-      2
-    );
+    await factoryContract["withdraw(uint256)"](2);
 
     // released funds into owner wallet
     await factoryContract
@@ -170,19 +167,13 @@ describe("Open Format", function () {
       ["release(address)"](address1.address);
 
     // withdraw revShare for token id 0;
-    await factoryContract["withdraw(address,uint256)"](
-      revShare.address,
-      0
-    );
+    await factoryContract["withdraw(uint256)"](0);
 
     // release funds into address1 wallet
     await factoryContract["release(address)"](owner.address);
 
     // withdraw revShare for token id 1;
-    await factoryContract["withdraw(address,uint256)"](
-      revShare.address,
-      1
-    );
+    await factoryContract["withdraw(uint256)"](1);
 
     // check correct amount has been released
     const newContractBalance = await balance(factoryContract.address);
@@ -302,28 +293,24 @@ describe("Open Format", function () {
       );
 
       // withdraw revShare for token id 1;
-      await factoryContract["withdraw(address,address,uint256)"](
+      await factoryContract["withdraw(address,uint256)"](
         erc20.address,
-        revShare.address,
         0
       );
 
       // withdraw revShare for token id 1;
-      await factoryContract["withdraw(address,address,uint256)"](
+      await factoryContract["withdraw(address,uint256)"](
         erc20.address,
-        revShare.address,
         1
       );
       // withdraw revShare for token id 2;
-      await factoryContract["withdraw(address,address,uint256)"](
+      await factoryContract["withdraw(address,uint256)"](
         erc20.address,
-        revShare.address,
         2
       );
       // withdraw revShare for token id 3;
-      await factoryContract["withdraw(address,address,uint256)"](
+      await factoryContract["withdraw(address,uint256)"](
         erc20.address,
-        revShare.address,
         3
       );
 
@@ -352,21 +339,18 @@ describe("Open Format", function () {
       const address1Balance = await erc20.balanceOf(address1.address);
 
       // withdraw revShare for token id 1;
-      await factoryContract["withdraw(address,address,uint256)"](
+      await factoryContract["withdraw(address,uint256)"](
         erc20.address,
-        revShare.address,
         1
       );
       // withdraw revShare for token id 2;
-      await factoryContract["withdraw(address,address,uint256)"](
+      await factoryContract["withdraw(address,uint256)"](
         erc20.address,
-        revShare.address,
         2
       );
       // withdraw revShare for token id 3;
-      await factoryContract["withdraw(address,address,uint256)"](
+      await factoryContract["withdraw(address,uint256)"](
         erc20.address,
-        revShare.address,
         3
       );
 
@@ -458,9 +442,8 @@ describe("Open Format", function () {
     );
 
     // withdraw revShare for token id 2;
-    await factoryContract["withdraw(address,address,uint256)"](
+    await factoryContract["withdraw(address,uint256)"](
       erc20.address,
-      revShare.address,
       2
     );
 
@@ -470,9 +453,8 @@ describe("Open Format", function () {
       ["release(address,address)"](erc20.address, address1.address);
 
     // withdraw revShare for token id 0;
-    await factoryContract["withdraw(address,address,uint256)"](
+    await factoryContract["withdraw(address,uint256)"](
       erc20.address,
-      revShare.address,
       0
     );
 
@@ -483,9 +465,8 @@ describe("Open Format", function () {
     );
 
     // withdraw revShare for token id 1;
-    await factoryContract["withdraw(address,address,uint256)"](
+    await factoryContract["withdraw(address,uint256)"](
       erc20.address,
-      revShare.address,
       1
     );
 

--- a/test/OpenFormat.js
+++ b/test/OpenFormat.js
@@ -73,9 +73,7 @@ describe("Open Format", function () {
   it("should deposit ETH into contract", async () => {
     const value = ethers.utils.parseEther("1");
 
-    await factoryContract
-      .connect(address1)
-      ["deposit(address)"](revShare.address, { value });
+    await factoryContract.connect(address1)["deposit()"]({ value });
 
     const contractBalance = await factoryContract.provider.getBalance(
       factoryContract.address
@@ -97,9 +95,7 @@ describe("Open Format", function () {
       ["mint()"]({ value: mintingPrice });
 
     // deposit some ETH via deposit() function
-    await factoryContract
-      .connect(address1)
-      ["deposit(address)"](revShare.address, { value });
+    await factoryContract.connect(address1)["deposit()"]({ value });
 
     // released funds into owner account
     const contractBalance = await factoryContract.provider.getBalance(
@@ -158,7 +154,7 @@ describe("Open Format", function () {
     // deposit some ETH via deposit() function
     await factoryContract
       .connect(address1)
-      ["deposit(address)"](revShare.address, { value: value2 });
+      ["deposit()"]({ value: value2 });
 
     const contractBalance = await balance(factoryContract.address);
 
@@ -266,11 +262,7 @@ describe("Open Format", function () {
       // deposit some ETH via deposit() function
       await factoryContract
         .connect(address1)
-        ["deposit(address,address,uint256)"](
-          revShare.address,
-          erc20.address,
-          value2
-        );
+        ["deposit(address,uint256)"](erc20.address, value2);
 
       // allocate 50% from owner => address1
       await factoryContract
@@ -459,11 +451,7 @@ describe("Open Format", function () {
     // deposit some ETH via deposit() function
     await factoryContract
       .connect(address1)
-      ["deposit(address,address,uint256)"](
-        revShare.address,
-        erc20.address,
-        value2
-      );
+      ["deposit(address,uint256)"](erc20.address, value2);
 
     const contractBalance = await erc20.balanceOf(
       factoryContract.address
@@ -773,9 +761,7 @@ describe("Open Format", function () {
         .connect(owner)
         .setApprovedDepositExtension(revShare.address);
 
-      await factoryContract
-        .connect(address1)
-        ["deposit(address)"](revShare.address, { value });
+      await factoryContract.connect(address1)["deposit()"]({ value });
 
       const balance = await factoryContract[
         "getSingleTokenBalance(address,uint256)"
@@ -802,11 +788,7 @@ describe("Open Format", function () {
       // deposit some ETH via deposit() function
       await factoryContract
         .connect(address1)
-        ["deposit(address,address,uint256)"](
-          revShare.address,
-          erc20.address,
-          value2
-        );
+        ["deposit(address,uint256)"](erc20.address, value2);
 
       const balance = await factoryContract[
         "getSingleTokenBalance(address,address,uint256)"


### PR DESCRIPTION
This PR simplifies the deposit and withdraw functions. I was unnecessarily passing through a `contractAddress` to each of these functions which wasn't doing anything except performing a check. I've updated to check, so the depositExtension address is no longer required to be passed in.