### PR TITLE
Feature: only owner or approved can withdraw token balances

### DIFF
--- a/abis/OpenFormat.json
+++ b/abis/OpenFormat.json
@@ -1,0 +1,1719 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "OpenFormat",
+  "sourceName": "contracts/OpenFormat.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "name_",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "symbol_",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "metadataURI_",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxSupply_",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "mintingPrice_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "approved",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "operator",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "approved",
+          "type": "bool"
+        }
+      ],
+      "name": "ApprovalForAll",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "contractAddress",
+          "type": "address"
+        }
+      ],
+      "name": "ApprovedDepositExtensionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "ApprovedRoyaltyExtensionCustomPctSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "contractAddress",
+          "type": "address"
+        }
+      ],
+      "name": "ApprovedRoyaltyExtensionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "string",
+          "name": "commissionType",
+          "type": "string"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "CommissionPaid",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "creator",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "metadataURI",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "symbol",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "name",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "maxSupply",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "mintingPrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "Created",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20PaymentReleased",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20TokenBalanceWithdrawn",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20TotalDepositedAmountUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "MaxSupplySet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "newTokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "Minted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "MintingPriceSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "previousOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "OwnershipTransferred",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "isPaused",
+          "type": "bool"
+        }
+      ],
+      "name": "PausedStateSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "name": "PayeeAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "name": "PayeeRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "PaymentReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "PaymentReleased",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "PrimaryCommissionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "percentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "RoyaltiesSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "RoyaltyPaid",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "salePrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "SalePriceSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "SecondaryCommissionSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "oldOwner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "salePrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "Sold",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "TokenBalanceWithdrawn",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "TotalDepositedAmountUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "_shares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "accounts",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "shares_",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "allocateShares",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvedDepositExtension",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "approvedRoyaltyExtension",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "burn",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "commissionAddress",
+          "type": "address"
+        }
+      ],
+      "name": "buy",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "buy",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "contractCreator",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "creatorOf",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "deposit",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "deposit",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getApproved",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getMaxSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getPrimaryCommissionPct",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getSecondaryCommissionPct",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getSingleTokenBalance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getSingleTokenBalance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getTokenSalePrice",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getTotalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "operator",
+          "type": "address"
+        }
+      ],
+      "name": "isApprovedForAll",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "metadataURI",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "mint",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "newTokenId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "commissionAddress",
+          "type": "address"
+        }
+      ],
+      "name": "mint",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "newTokenId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "mintingPrice",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ownerOf",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "payee",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "primaryCommissionPct",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "release",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "release",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "released",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "released",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "renounceOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "royaltyInfo",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "royaltyAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "safeTransferFrom",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_data",
+          "type": "bytes"
+        }
+      ],
+      "name": "safeTransferFrom",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "secondaryCommissionPct",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "operator",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "approved",
+          "type": "bool"
+        }
+      ],
+      "name": "setApprovalForAll",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "contractAddress_",
+          "type": "address"
+        }
+      ],
+      "name": "setApprovedDepositExtension",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "contractAddress_",
+          "type": "address"
+        }
+      ],
+      "name": "setApprovedRoyaltyExtension",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount_",
+          "type": "uint256"
+        }
+      ],
+      "name": "setApprovedRoyaltyExtensionCustomPct",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "setMaxSupply",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "setMintingPrice",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount_",
+          "type": "uint256"
+        }
+      ],
+      "name": "setPrimaryCommissionPct",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "royaltyReceiver",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_royaltiesPct",
+          "type": "uint256"
+        }
+      ],
+      "name": "setRoyalties",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount_",
+          "type": "uint256"
+        }
+      ],
+      "name": "setSecondaryCommissionPct",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_salePrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "setTokenSalePrice",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "shares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        }
+      ],
+      "name": "supportsInterface",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "togglePausedState",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "tokenByIndex",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "index",
+          "type": "uint256"
+        }
+      ],
+      "name": "tokenOfOwnerByIndex",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "tokenURI",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalDepositedAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalDepositedReleased",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "totalReleased",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalReleased",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newOwner",
+          "type": "address"
+        }
+      ],
+      "name": "transferOwnership",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "withdraw",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "withdraw",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ],
+  "bytecode": "0x60806040523480156200001157600080fd5b506040516200502a3803806200502a83398101604081905262000034916200045d565b8451859085906200004d90600090602085019062000328565b5080516200006390600190602084019062000328565b505050620000806200007a620000fc60201b60201c565b62000100565b6200008d33606462000152565b8251620000a290602190602086019062000328565b50601c829055601d81905560405133907fc1d48f1736a531302a78b74590d0777fc17b24d24429d1e262591b9c4a10e55890620000e990869088908a90889088906200052b565b60405180910390a2505050505062000605565b3390565b600c80546001600160a01b038381166001600160a01b0319831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b6001600160a01b038216620001c35760405162461bcd60e51b815260206004820152602c60248201527f5061796d656e7453706c69747465723a206163636f756e74206973207468652060448201526b7a65726f206164647265737360a01b60648201526084015b60405180910390fd5b60008111620002155760405162461bcd60e51b815260206004820152601d60248201527f5061796d656e7453706c69747465723a207368617265732061726520300000006044820152606401620001ba565b6001600160a01b03821660009081526010602052604090205415620002915760405162461bcd60e51b815260206004820152602b60248201527f5061796d656e7453706c69747465723a206163636f756e7420616c726561647960448201526a206861732073686172657360a81b6064820152608401620001ba565b60128054600181019091557fbb8a6a4669ba250d26cd7a459eca9d215f8307e33aebe50379bc5a3617ec34440180546001600160a01b0319166001600160a01b038416908117909155600081815260106020908152604091829020849055815192835282018390527f40c340f65e17194d14ddddb073d3c9f888e3cb52b5aae0c6c7706b4fbc905fac910160405180910390a15050565b8280546200033690620005b2565b90600052602060002090601f0160209004810192826200035a5760008555620003a5565b82601f106200037557805160ff1916838001178555620003a5565b82800160010185558215620003a5579182015b82811115620003a557825182559160200191906001019062000388565b50620003b3929150620003b7565b5090565b5b80821115620003b35760008155600101620003b8565b600082601f830112620003df578081fd5b81516001600160401b0380821115620003fc57620003fc620005ef565b604051601f8301601f19908116603f01168101908282118183101715620004275762000427620005ef565b8160405283815286602085880101111562000440578485fd5b620004538460208301602089016200057f565b9695505050505050565b600080600080600060a0868803121562000475578081fd5b85516001600160401b03808211156200048c578283fd5b6200049a89838a01620003ce565b96506020880151915080821115620004b0578283fd5b620004be89838a01620003ce565b95506040880151915080821115620004d4578283fd5b50620004e388828901620003ce565b606088015160809098015196999598509695949350505050565b60008151808452620005178160208601602086016200057f565b601f01601f19169290920160200192915050565b60a0815260006200054060a0830188620004fd565b8281036020840152620005548188620004fd565b905082810360408401526200056a8187620004fd565b60608401959095525050608001529392505050565b60005b838110156200059c57818101518382015260200162000582565b83811115620005ac576000848401525b50505050565b600181811c90821680620005c757607f821691505b60208210811415620005e957634e487b7160e01b600052602260045260246000fd5b50919050565b634e487b7160e01b600052604160045260246000fd5b614a1580620006156000396000f3fe6080604052600436106103e85760003560e01c80636a62784211610208578063ae9df3d411610118578063d0e30db0116100ab578063e33b7de31161007a578063e33b7de314610bdc578063e985e9c514610bf1578063f2fde38b14610c3a578063f3fef3a314610c5a578063fdf8967314610c6d57600080fd5b8063d0e30db014610b76578063d684beff14610b7e578063d79779b214610b93578063d96a094a14610bc957600080fd5b8063bcc1c53f116100e7578063bcc1c53f14610aeb578063c4e41b2214610b0b578063c87b56dd14610b20578063ce7c2ac214610b4057600080fd5b8063ae9df3d414610a5e578063b34c8caf14610a7e578063b88d4fde14610aab578063bbf85e8014610acb57600080fd5b80638b83209b1161019b5780639852595c1161016a5780639852595c146109a8578063a22cb465146109de578063a2606334146109fe578063a7041d7a14610a1e578063ac4b4a1014610a3e57600080fd5b80638b83209b146109355780638c7ea24b146109555780638da5cb5b1461097557806395d89b411461099357600080fd5b80637deb6025116101d75780637deb6025146108cd578063814a76fe146108e05780638417b47f146109005780638859e91f1461092057600080fd5b80636a627842146108655780636f8b44b01461087857806370a0823114610898578063715018a6146108b857600080fd5b806335db70b51161030357806348b750441161029657806359aa03aa1161026557806359aa03aa146107d55780635c975abb146107f55780635f0112011461080f57806363167ced1461082f5780636352211e1461084557600080fd5b806348b750441461074a5780634c0f38c21461076a5780634f6ccce71461077f578063589a17431461079f57600080fd5b806342966c68116102d257806342966c68146106e1578063438ea94a1461070157806347d91e031461072157806347e7ef241461073757600080fd5b806335db70b5146106505780633e48d88f14610666578063406072a91461067b57806342842e0e146106c157600080fd5b806318eef3951161037b57806323b872dd1161034a57806323b872dd146105be5780632a55205a146105de5780632e1a7d4d1461061d5780632f745c591461063057600080fd5b806318eef3951461053c57806318fbcdb314610569578063191655871461057e5780631e2f73b11461059e57600080fd5b8063095ea7b3116103b7578063095ea7b3146104da5780631249c58b146104fc578063172958941461051257806318160ddd1461052757600080fd5b806301ffc9a71461043657806303ee438c1461046b57806306fdde031461048d578063081812fc146104a257600080fd5b36610431577f6ef95f06320e7a25a04a175ca677b7052bdd97131872c2192525a629f51be77033604080516001600160a01b0390921682523460208301520160405180910390a1005b600080fd5b34801561044257600080fd5b50610456610451366004614563565b610c8d565b60405190151581526020015b60405180910390f35b34801561047757600080fd5b50610480610c9e565b60405161046291906146a7565b34801561049957600080fd5b50610480610d2c565b3480156104ae57600080fd5b506104c26104bd3660046145ad565b610dbe565b6040516001600160a01b039091168152602001610462565b3480156104e657600080fd5b506104fa6104f5366004614486565b610e58565b005b610504610f6e565b604051908152602001610462565b34801561051e57600080fd5b50600e54610504565b34801561053357600080fd5b50600954610504565b34801561054857600080fd5b506105046105573660046145ad565b60009081526018602052604090205490565b34801561057557600080fd5b50601f54610504565b34801561058a57600080fd5b506104fa6105993660046142ec565b610fde565b3480156105aa57600080fd5b50601b546104c2906001600160a01b031681565b3480156105ca57600080fd5b506104fa6105d9366004614340565b611120565b3480156105ea57600080fd5b506105fe6105f9366004614601565b611152565b604080516001600160a01b039093168352602083019190915201610462565b61050461062b3660046145ad565b6111a7565b34801561063c57600080fd5b5061050461064b366004614486565b611352565b34801561065c57600080fd5b50610504601d5481565b34801561067257600080fd5b50600f54610504565b34801561068757600080fd5b5061050461069636600461459b565b6001600160a01b03918216600090815260146020908152604080832093909416825291909152205490565b3480156106cd57600080fd5b506104fa6106dc366004614340565b6113e8565b3480156106ed57600080fd5b506104fa6106fc3660046145ad565b611403565b34801561070d57600080fd5b5061050461071c366004614486565b611459565b34801561072d57600080fd5b50610504601f5481565b6104fa610745366004614486565b611511565b34801561075657600080fd5b506104fa61076536600461459b565b611760565b34801561077657600080fd5b50601c54610504565b34801561078b57600080fd5b5061050461079a3660046145ad565b611980565b3480156107ab57600080fd5b506104c26107ba3660046145ad565b6000908152601760205260409020546001600160a01b031690565b3480156107e157600080fd5b506104fa6107f03660046144de565b611a21565b34801561080157600080fd5b506020546104569060ff1681565b34801561081b57600080fd5b506104fa61082a3660046142ec565b611d39565b34801561083b57600080fd5b50610504601e5481565b34801561085157600080fd5b506104c26108603660046145ad565b611e0b565b6105046108733660046142ec565b611e82565b34801561088457600080fd5b506104fa6108933660046145ad565b611f80565b3480156108a457600080fd5b506105046108b33660046142ec565b611fdd565b3480156108c457600080fd5b506104fa612064565b6104566108db3660046145dd565b61209a565b3480156108ec57600080fd5b506104fa6108fb366004614601565b612196565b34801561090c57600080fd5b506104fa61091b3660046145ad565b6121e9565b34801561092c57600080fd5b50601e54610504565b34801561094157600080fd5b506104c26109503660046145ad565b612246565b34801561096157600080fd5b506104fa610970366004614486565b612284565b34801561098157600080fd5b50600c546001600160a01b03166104c2565b34801561099f57600080fd5b50610480612365565b3480156109b457600080fd5b506105046109c33660046142ec565b6001600160a01b031660009081526011602052604090205490565b3480156109ea57600080fd5b506104fa6109f9366004614459565b612374565b348015610a0a57600080fd5b506104fa610a193660046145ad565b61237f565b348015610a2a57600080fd5b506104fa610a393660046145ad565b6123fe565b348015610a4a57600080fd5b506019546104c2906001600160a01b031681565b348015610a6a57600080fd5b50610504610a79366004614340565b612519565b348015610a8a57600080fd5b50610504610a993660046142ec565b60106020526000908152604090205481565b348015610ab757600080fd5b506104fa610ac6366004614380565b6125dc565b348015610ad757600080fd5b506104fa610ae63660046142ec565b612614565b348015610af757600080fd5b50601a546104c2906001600160a01b031681565b348015610b1757600080fd5b50610504612688565b348015610b2c57600080fd5b50610480610b3b3660046145ad565b612693565b348015610b4c57600080fd5b50610504610b5b3660046142ec565b6001600160a01b031660009081526010602052604090205490565b6104fa6127a4565b348015610b8a57600080fd5b506104fa612881565b348015610b9f57600080fd5b50610504610bae3660046142ec565b6001600160a01b031660009081526013602052604090205490565b610456610bd73660046145ad565b6128f4565b348015610be857600080fd5b50600d54610504565b348015610bfd57600080fd5b50610456610c0c366004614308565b6001600160a01b03918216600090815260056020908152604080832093909416825291909152205460ff1690565b348015610c4657600080fd5b506104fa610c553660046142ec565b612900565b610504610c68366004614486565b61299b565b348015610c7957600080fd5b506104fa610c883660046145ad565b612b83565b6000610c9882612c02565b92915050565b60218054610cab90614945565b80601f0160208091040260200160405190810160405280929190818152602001828054610cd790614945565b8015610d245780601f10610cf957610100808354040283529160200191610d24565b820191906000526020600020905b815481529060010190602001808311610d0757829003601f168201915b505050505081565b606060008054610d3b90614945565b80601f0160208091040260200160405190810160405280929190818152602001828054610d6790614945565b8015610db45780601f10610d8957610100808354040283529160200191610db4565b820191906000526020600020905b815481529060010190602001808311610d9757829003601f168201915b5050505050905090565b6000818152600260205260408120546001600160a01b0316610e3c5760405162461bcd60e51b815260206004820152602c60248201527f4552433732313a20617070726f76656420717565727920666f72206e6f6e657860448201526b34b9ba32b73a103a37b5b2b760a11b60648201526084015b60405180910390fd5b506000908152600460205260409020546001600160a01b031690565b6000610e6382611e0b565b9050806001600160a01b0316836001600160a01b03161415610ed15760405162461bcd60e51b815260206004820152602160248201527f4552433732313a20617070726f76616c20746f2063757272656e74206f776e656044820152603960f91b6064820152608401610e33565b336001600160a01b0382161480610eed5750610eed8133610c0c565b610f5f5760405162461bcd60e51b815260206004820152603860248201527f4552433732313a20617070726f76652063616c6c6572206973206e6f74206f7760448201527f6e6572206e6f7220617070726f76656420666f7220616c6c00000000000000006064820152608401610e33565b610f698383612c27565b505050565b60205460009060ff1615610f945760405162461bcd60e51b8152600401610e33906147bf565b601d54341015610fd15760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303160c01b6044820152606401610e33565b610fd9612c95565b905090565b6001600160a01b0381166000908152601060205260409020546110135760405162461bcd60e51b8152600401610e339061470c565b6000600f54600e546110259190614902565b600d5461103290476148ab565b61103c9190614902565b905060006110698383611064866001600160a01b031660009081526011602052604090205490565b612da0565b9050806110885760405162461bcd60e51b8152600401610e3390614774565b6001600160a01b038316600090815260116020526040812080548392906110b09084906148ab565b9250508190555080600d60008282546110c991906148ab565b909155506110d990508382612ddc565b604080516001600160a01b0385168152602081018390527fdf20fd1e76bc69d672e4814fafb2c449bba3a5369d8359adf9e05e6fde87b056910160405180910390a1505050565b61112b335b82612ef5565b6111475760405162461bcd60e51b8152600401610e3390614838565b610f69838383612fe8565b60408051808201909152600b546001600160a01b038116808352600160a01b90910462ffffff166020830181905290916000916127109061119390866148e3565b61119d91906148c3565b9150509250929050565b6000816111b333611125565b6111cf5760405162461bcd60e51b8152600401610e33906147e1565b6019546001600160a01b03166111f75760405162461bcd60e51b8152600401610e3390614889565b600061120284611e0b565b6019546040516321c754a560e11b8152306004820152602481018790529192506000916001600160a01b039091169063438ea94a9060440160206040518083038186803b15801561125257600080fd5b505afa158015611266573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061128a91906145c5565b905061129f6001600160a01b03831682612ddc565b80600f60008282546112b191906148ab565b9091555050601954604051630e6621ff60e11b815260006004820152602481018790526001600160a01b0390911690631ccc43fe90604401600060405180830381600087803b15801561130357600080fd5b505af1158015611317573d6000803e3d6000fd5b50506040518392508791507fd2e9df57c00b23ba7ee3ed404df528700b0f0990b7292602d48fb3b9764e507690600090a39250505b50919050565b600061135d83611fdd565b82106113bf5760405162461bcd60e51b815260206004820152602b60248201527f455243373231456e756d657261626c653a206f776e657220696e646578206f7560448201526a74206f6620626f756e647360a81b6064820152608401610e33565b506001600160a01b03919091166000908152600760209081526040808320938352929052205490565b610f69838383604051806020016040528060008152506125dc565b8061140d33611125565b6114295760405162461bcd60e51b8152600401610e33906147e1565b60205460ff161561144c5760405162461bcd60e51b8152600401610e33906147bf565b61145582613193565b5050565b6019546000906001600160a01b03166114845760405162461bcd60e51b8152600401610e3390614889565b6019546040516321c754a560e11b81526001600160a01b03858116600483015260248201859052600092169063438ea94a9060440160206040518083038186803b1580156114d157600080fd5b505afa1580156114e5573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061150991906145c5565b949350505050565b604051636eb1769f60e11b81523360048201523060248201526000906001600160a01b0384169063dd62ed3e9060440160206040518083038186803b15801561155957600080fd5b505afa15801561156d573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061159191906145c5565b9050600061159e60095490565b6019549091506001600160a01b03166115c95760405162461bcd60e51b8152600401610e3390614889565b828210156116045760405162461bcd60e51b815260206004820152600860248201526713d18e914b4c0c0d60c21b6044820152606401610e33565b6040516323b872dd60e01b8152336004820152306024820152604481018490526001600160a01b038516906323b872dd90606401602060405180830381600087803b15801561165257600080fd5b505af1158015611666573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061168a9190614547565b5060195460405162f9874d60e31b81526001600160a01b0386811660048301526024820186905260448201849052909116906307cc3a6890606401600060405180830381600087803b1580156116df57600080fd5b505af11580156116f3573d6000803e3d6000fd5b505050506001600160a01b0384166000908152601560205260408120805485929061171f9084906148ab565b909155505060405134906001600160a01b038616907f8d5b2df7eba39b5e2a616e9c89e0c253c36b92c638f32ad4f4e2bedc0ee5ba7d90600090a350505050565b6001600160a01b0381166000908152601060205260409020546117955760405162461bcd60e51b8152600401610e339061470c565b6001600160a01b03821660009081526016602090815260408083205460159092528220546117c39190614902565b6001600160a01b0384166000908152601360205260409020546040516370a0823160e01b81523060048201526001600160a01b038616906370a082319060240160206040518083038186803b15801561181b57600080fd5b505afa15801561182f573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061185391906145c5565b61185d91906148ab565b6118679190614902565b905060006118a0838361106487876001600160a01b03918216600090815260146020908152604080832093909416825291909152205490565b9050806118bf5760405162461bcd60e51b8152600401610e3390614774565b6001600160a01b038085166000908152601460209081526040808320938716835292905290812080548392906118f69084906148ab565b90915550506001600160a01b038416600090815260136020526040812080548392906119239084906148ab565b90915550611934905084848361319c565b604080516001600160a01b038581168252602082018490528616917f3be5b7a71e84ed12875d241991c70855ac5817d847039e17a9d895c1ceb0f18a910160405180910390a250505050565b600061198b60095490565b82106119ee5760405162461bcd60e51b815260206004820152602c60248201527f455243373231456e756d657261626c653a20676c6f62616c20696e646578206f60448201526b7574206f6620626f756e647360a01b6064820152608401610e33565b60098281548110611a0f57634e487b7160e01b600052603260045260246000fd5b90600052602060002001549050919050565b828114611a8b5760405162461bcd60e51b815260206004820152603260248201527f5061796d656e7453706c69747465723a2070617965657320616e6420736861726044820152710cae640d8cadccee8d040dad2e6dac2e8c6d60731b6064820152608401610e33565b82611ad85760405162461bcd60e51b815260206004820152601a60248201527f5061796d656e7453706c69747465723a206e6f207061796565730000000000006044820152606401610e33565b60005b83811015611d3257828282818110611b0357634e487b7160e01b600052603260045260246000fd5b9050602002013560106000336001600160a01b03166001600160a01b03168152602001908152602001600020541015611ba6576040805162461bcd60e51b81526020600482015260248101919091527f5061796d656e7453706c69747465723a206163636f756e7420646f6573206e6f60448201527f74206861766520656e6f7567682073686172657320746f20616c6c6f636174656064820152608401610e33565b828282818110611bc657634e487b7160e01b600052603260045260246000fd5b33600090815260106020908152604090912054611bea949190920201359150614902565b3360009081526010602081905260408220929092559081878785818110611c2157634e487b7160e01b600052603260045260246000fd5b9050602002016020810190611c3691906142ec565b6001600160a01b03166001600160a01b03168152602001908152602001600020541115611cc657611cc1858583818110611c8057634e487b7160e01b600052603260045260246000fd5b9050602002016020810190611c9591906142ec565b848484818110611cb557634e487b7160e01b600052603260045260246000fd5b905060200201356131ee565b611d2a565b611d2a858583818110611ce957634e487b7160e01b600052603260045260246000fd5b9050602002016020810190611cfe91906142ec565b848484818110611d1e57634e487b7160e01b600052603260045260246000fd5b90506020020135613232565b600101611adb565b5050505050565b600c546001600160a01b03163314611d635760405162461bcd60e51b8152600401610e3390614803565b601980546001600160a01b0319166001600160a01b0383169081179091556040805163df2845b560e01b8152905163df2845b59160048082019260009290919082900301818387803b158015611db857600080fd5b505af1158015611dcc573d6000803e3d6000fd5b50506019546040516001600160a01b0390911692507f7947799a5d3281fff4a4457606b1aaa700d7ddecbe5b6143ff45b6c9866a8cc29150600090a250565b6000818152600260205260408120546001600160a01b031680610c985760405162461bcd60e51b815260206004820152602960248201527f4552433732313a206f776e657220717565727920666f72206e6f6e657869737460448201526832b73a103a37b5b2b760b91b6064820152608401610e33565b60205460009060ff1615611ea85760405162461bcd60e51b8152600401610e33906147bf565b601d54341015611ee55760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303160c01b6044820152606401610e33565b601e5415611f78576000611efb601e54346133fe565b9050611f106001600160a01b03841682612ddc565b604051667072696d61727960c81b81526001600160a01b0384169060070160405180910390207f522c39d7156b7dd9419c7853d069ac52655fb23c5ec017f319477ad7bef213aa611f6060095490565b604080519182523460208301520160405180910390a3505b610c98612c95565b600c546001600160a01b03163314611faa5760405162461bcd60e51b8152600401610e3390614803565b601c81905560405181907facc639f1ff310faf48650d02a82bd24c924e45a5050fc931245096ac57c309d990600090a250565b60006001600160a01b0382166120485760405162461bcd60e51b815260206004820152602a60248201527f4552433732313a2062616c616e636520717565727920666f7220746865207a65604482015269726f206164647265737360b01b6064820152608401610e33565b506001600160a01b031660009081526003602052604090205490565b600c546001600160a01b0316331461208e5760405162461bcd60e51b8152600401610e3390614803565b6120986000613416565b565b60006001600160a01b0382166120dd5760405162461bcd60e51b815260206004820152600860248201526727a31d229698181960c11b6044820152606401610e33565b600083815260186020526040812054601f549091906120fc90836133fe565b601f549091501561217a5761211a6001600160a01b03851682612ddc565b604051687365636f6e6461727960b81b81526001600160a01b0385169060090160408051918290038220888352346020840152917f522c39d7156b7dd9419c7853d069ac52655fb23c5ec017f319477ad7bef213aa910160405180910390a35b61218d856121883484613468565b613474565b95945050505050565b60205460ff16156121b95760405162461bcd60e51b8152600401610e33906147bf565b816121c333611125565b6121df5760405162461bcd60e51b8152600401610e33906147e1565b610f698383613690565b600c546001600160a01b031633146122135760405162461bcd60e51b8152600401610e3390614803565b601d81905560405181907f02dd4e125a287edc7a6a887552dc7be35f4fdabe8afd6ae78f98b448d4e1a86690600090a250565b60006012828154811061226957634e487b7160e01b600052603260045260246000fd5b6000918252602090912001546001600160a01b031692915050565b600c546001600160a01b031633146122ae5760405162461bcd60e51b8152600401610e3390614803565b600081116122e95760405162461bcd60e51b815260206004820152600860248201526713d18e914b4c0c0d60c21b6044820152606401610e33565b6001600160a01b03821661232a5760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303560c01b6044820152606401610e33565b61233482826136e1565b604051819030907f908669f35f6fb3977a956ba70597841fe541d1e8491ca3c025161e258d3bfdb690600090a35050565b606060018054610d3b90614945565b61145533838361377d565b600c546001600160a01b031633146123a95760405162461bcd60e51b8152600401610e3390614803565b6127108111156123cb5760405162461bcd60e51b8152600401610e3390614752565b601f81905560405181907f905c2604b04c9fa2b09e05ab34ccae93abf21f5edd19a139c406fe9398f752a090600090a250565b600c546001600160a01b031633146124285760405162461bcd60e51b8152600401610e3390614803565b61271081111561244a5760405162461bcd60e51b8152600401610e3390614752565b601a546001600160a01b031661248d5760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303760c01b6044820152606401610e33565b601a5460405163074ae54d60e01b8152600481018390526001600160a01b039091169063074ae54d90602401600060405180830381600087803b1580156124d357600080fd5b505af11580156124e7573d6000803e3d6000fd5b50506040518392507f67c41861347f4f7588ff0bd41c40943750a52c35859b99dac7d30beda950088c9150600090a250565b6019546000906001600160a01b03166125445760405162461bcd60e51b8152600401610e3390614889565b601954604051632ba77cf560e21b81526001600160a01b038681166004830152858116602483015260448201859052600092169063ae9df3d49060640160206040518083038186803b15801561259957600080fd5b505afa1580156125ad573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906125d191906145c5565b9150505b9392505050565b6125e63383612ef5565b6126025760405162461bcd60e51b8152600401610e3390614838565b61260e8484848461384c565b50505050565b600c546001600160a01b0316331461263e5760405162461bcd60e51b8152600401610e3390614803565b601a80546001600160a01b0319166001600160a01b0383169081179091556040517f5db3fb7335b6ec1dfcfd94d09bc1904829d1b8fdba0dc0ad6ee68d71650652ae90600090a250565b6000610fd960095490565b6000818152600260205260409020546060906001600160a01b03166127125760405162461bcd60e51b815260206004820152602f60248201527f4552433732314d657461646174613a2055524920717565727920666f72206e6f60448201526e3732bc34b9ba32b73a103a37b5b2b760891b6064820152608401610e33565b6021805461271f90614945565b80601f016020809104026020016040519081016040528092919081815260200182805461274b90614945565b80156127985780601f1061276d57610100808354040283529160200191612798565b820191906000526020600020905b81548152906001019060200180831161277b57829003601f168201915b50505050509050919050565b6019546001600160a01b03166127cc5760405162461bcd60e51b8152600401610e3390614889565b60006127d760095490565b60195460405163a64271f160e01b8152346004820152602481018390529192506001600160a01b03169063a64271f190604401600060405180830381600087803b15801561282457600080fd5b505af1158015612838573d6000803e3d6000fd5b5050505034600e600082825461284e91906148ab565b909155505060405134907f3903d05344bfbe173a5084aa4d3a99187eff3f7bfb3db786c814e7eddd9b3cd590600090a250565b600c546001600160a01b031633146128ab5760405162461bcd60e51b8152600401610e3390614803565b6020805460ff8082161560ff199092168217835560405191161581527fa9bfed3d98385b3777389e321dbde773cf7d335fa604fefbae3dca93564f5586910160405180910390a1565b6000610c988234613474565b600c546001600160a01b0316331461292a5760405162461bcd60e51b8152600401610e3390614803565b6001600160a01b03811661298f5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b6064820152608401610e33565b61299881613416565b50565b6000816129a733611125565b6129c35760405162461bcd60e51b8152600401610e33906147e1565b6019546001600160a01b03166129eb5760405162461bcd60e51b8152600401610e3390614889565b60006129f684611e0b565b601954604051632ba77cf560e21b81526001600160a01b038881166004830152306024830152604482018890529293506000929091169063ae9df3d49060640160206040518083038186803b158015612a4e57600080fd5b505afa158015612a62573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612a8691906145c5565b6001600160a01b038716600090815260166020526040812080549293508392909190612ab39084906148ab565b909155505060195460405163fdb047b160e01b81526001600160a01b03888116600483015260006024830152604482018890529091169063fdb047b190606401600060405180830381600087803b158015612b0d57600080fd5b505af1158015612b21573d6000803e3d6000fd5b50612b3a925050506001600160a01b038716838361319c565b6040516001600160a01b0387168152819086907f12ff21bbdebdfd7045c78e9aa73dc7777831b172e9097bc41bedd40f841c0afd9060200160405180910390a395945050505050565b600c546001600160a01b03163314612bad5760405162461bcd60e51b8152600401610e3390614803565b612710811115612bcf5760405162461bcd60e51b8152600401610e3390614752565b601e81905560405181907fb27a19d53c022a09a344f42378e7d232d66b643564218cbfc93c98c93a2bc7af90600090a250565b60006001600160e01b0319821663780e9d6360e01b1480610c985750610c988261387f565b600081815260046020526040902080546001600160a01b0319166001600160a01b0384169081179091558190612c5c82611e0b565b6001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92560405160405180910390a45050565b6000612ca060095490565b9050612cbc3382604051806020016040528060008152506138cf565b600081815260176020526040902080546001600160a01b0319163317905560218054612d70918391612ced90614945565b80601f0160208091040260200160405190810160405280929190818152602001828054612d1990614945565b8015612d665780601f10612d3b57610100808354040283529160200191612d66565b820191906000526020600020905b815481529060010190602001808311612d4957829003601f168201915b5050505050613902565b604051339082907fb9203d657e9c0ec8274c818292ab0f58b04e1970050716891770eb1bab5d655e90600090a390565b6001600160a01b0383166000908152601060205260408120548290606490612dc890866148e3565b612dd291906148c3565b6115099190614902565b80471015612e2c5760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a20696e73756666696369656e742062616c616e63650000006044820152606401610e33565b6000826001600160a01b03168260405160006040518083038185875af1925050503d8060008114612e79576040519150601f19603f3d011682016040523d82523d6000602084013e612e7e565b606091505b5050905080610f695760405162461bcd60e51b815260206004820152603a60248201527f416464726573733a20756e61626c6520746f2073656e642076616c75652c207260448201527f6563697069656e74206d617920686176652072657665727465640000000000006064820152608401610e33565b6000818152600260205260408120546001600160a01b0316612f6e5760405162461bcd60e51b815260206004820152602c60248201527f4552433732313a206f70657261746f7220717565727920666f72206e6f6e657860448201526b34b9ba32b73a103a37b5b2b760a11b6064820152608401610e33565b6000612f7983611e0b565b9050806001600160a01b0316846001600160a01b03161480612fb45750836001600160a01b0316612fa984610dbe565b6001600160a01b0316145b8061150957506001600160a01b0380821660009081526005602090815260408083209388168352929052205460ff16611509565b826001600160a01b0316612ffb82611e0b565b6001600160a01b0316146130635760405162461bcd60e51b815260206004820152602960248201527f4552433732313a207472616e73666572206f6620746f6b656e2074686174206960448201526839903737ba1037bbb760b91b6064820152608401610e33565b6001600160a01b0382166130c55760405162461bcd60e51b8152602060048201526024808201527f4552433732313a207472616e7366657220746f20746865207a65726f206164646044820152637265737360e01b6064820152608401610e33565b6130d083838361399c565b6130db600082612c27565b6001600160a01b0383166000908152600360205260408120805460019290613104908490614902565b90915550506001600160a01b03821660009081526003602052604081208054600192906131329084906148ab565b909155505060008181526002602052604080822080546001600160a01b0319166001600160a01b0386811691821790925591518493918716917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef91a4505050565b612998816139a7565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180516001600160e01b031663a9059cbb60e01b179052610f699084906139e7565b6001600160a01b0382166000908152601060205260409020546132129082906148ab565b6001600160a01b0390921660009081526010602052604090209190915550565b6001600160a01b03821661329d5760405162461bcd60e51b815260206004820152602c60248201527f5061796d656e7453706c69747465723a206163636f756e74206973207468652060448201526b7a65726f206164647265737360a01b6064820152608401610e33565b600081116132ed5760405162461bcd60e51b815260206004820152601d60248201527f5061796d656e7453706c69747465723a207368617265732061726520300000006044820152606401610e33565b6001600160a01b038216600090815260106020526040902054156133675760405162461bcd60e51b815260206004820152602b60248201527f5061796d656e7453706c69747465723a206163636f756e7420616c726561647960448201526a206861732073686172657360a81b6064820152608401610e33565b60128054600181019091557fbb8a6a4669ba250d26cd7a459eca9d215f8307e33aebe50379bc5a3617ec34440180546001600160a01b0319166001600160a01b038416908117909155600081815260106020908152604091829020849055815192835282018390527f40c340f65e17194d14ddddb073d3c9f888e3cb52b5aae0c6c7706b4fbc905fac910160405180910390a15050565b60006125d56127106134108486613ab9565b90613ac5565b600c80546001600160a01b038381166001600160a01b0319831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b60006125d58284614902565b600082815260186020526040812054806134bb5760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303760c01b6044820152606401610e33565b808310156134f65760405162461bcd60e51b815260206004820152600860248201526709e8c748a5a6060760c31b6044820152606401610e33565b600061350185611e0b565b905060003360405163152a902d60e11b81526000600482018190526024820186905291925081903090632a55205a90604401604080518083038186803b15801561354a57600080fd5b505afa15801561355e573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061358291906144b1565b601a5491935091506001600160a01b0316156135b357601a546135ae906001600160a01b031682612ddc565b613603565b8015613603576135cc6001600160a01b03831682612ddc565b60405181906001600160a01b038416907fbc86de696edc3350c664d50abf25f24e7e1251f1469ad925b25fe36927270d4390600090a35b6136206136108683613468565b6001600160a01b03861690612ddc565b826001600160a01b0316846001600160a01b0316897f23f50d55776d8003622a982ade45a6c7f083116c8dbbcd980f59942f440badb18860405161366691815260200190565b60405180910390a461367785613ad1565b61368284848a612fe8565b506001979650505050505050565b600082815260186020526040908190208290555182907fe23ea816dce6d7f5c0b85cbd597e7c3b97b2453791152c0b94e5e5c5f314d2f0906136d59084815260200190565b60405180910390a25050565b6127108111156137335760405162461bcd60e51b815260206004820152601a60248201527f45524332393831526f79616c746965733a20546f6f20686967680000000000006044820152606401610e33565b604080518082019091526001600160a01b0390921680835262ffffff9091166020909201829052600b8054600160a01b9093026001600160b81b0319909316909117919091179055565b816001600160a01b0316836001600160a01b031614156137df5760405162461bcd60e51b815260206004820152601960248201527f4552433732313a20617070726f766520746f2063616c6c6572000000000000006044820152606401610e33565b6001600160a01b03838116600081815260056020908152604080832094871680845294825291829020805460ff191686151590811790915591519182527f17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31910160405180910390a3505050565b613857848484612fe8565b61386384848484613aef565b61260e5760405162461bcd60e51b8152600401610e33906146ba565b60006001600160e01b031982166380ac58cd60e01b14806138b057506001600160e01b03198216635b5e139f60e01b145b80610c9857506301ffc9a760e01b6001600160e01b0319831614610c98565b6138d98383613bfc565b6138e66000848484613aef565b610f695760405162461bcd60e51b8152600401610e33906146ba565b6000828152600260205260409020546001600160a01b031661397d5760405162461bcd60e51b815260206004820152602e60248201527f45524337323155524953746f726167653a2055524920736574206f66206e6f6e60448201526d32bc34b9ba32b73a103a37b5b2b760911b6064820152608401610e33565b60008281526006602090815260409091208251610f69928401906141d3565b610f69838383613d4a565b6139b081613e02565b600081815260066020526040902080546139c990614945565b15905061299857600081815260066020526040812061299891614257565b6000613a3c826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b0316613ea99092919063ffffffff16565b805190915015610f695780806020019051810190613a5a9190614547565b610f695760405162461bcd60e51b815260206004820152602a60248201527f5361666545524332303a204552433230206f7065726174696f6e20646964206e6044820152691bdd081cdd58d8d9595960b21b6064820152608401610e33565b60006125d582846148e3565b60006125d582846148c3565b6000613add3483613468565b90508015611455576114553382612ddc565b60006001600160a01b0384163b15613bf157604051630a85bd0160e11b81526001600160a01b0385169063150b7a0290613b3390339089908890889060040161466a565b602060405180830381600087803b158015613b4d57600080fd5b505af1925050508015613b7d575060408051601f3d908101601f19168201909252613b7a9181019061457f565b60015b613bd7573d808015613bab576040519150601f19603f3d011682016040523d82523d6000602084013e613bb0565b606091505b508051613bcf5760405162461bcd60e51b8152600401610e33906146ba565b805181602001fd5b6001600160e01b031916630a85bd0160e11b149050611509565b506001949350505050565b6001600160a01b038216613c525760405162461bcd60e51b815260206004820181905260248201527f4552433732313a206d696e7420746f20746865207a65726f20616464726573736044820152606401610e33565b6000818152600260205260409020546001600160a01b031615613cb75760405162461bcd60e51b815260206004820152601c60248201527f4552433732313a20746f6b656e20616c7265616479206d696e746564000000006044820152606401610e33565b613cc36000838361399c565b6001600160a01b0382166000908152600360205260408120805460019290613cec9084906148ab565b909155505060008181526002602052604080822080546001600160a01b0319166001600160a01b03861690811790915590518392907fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef908290a45050565b6001600160a01b038316613da557613da081600980546000838152600a60205260408120829055600182018355919091527f6e1540171b6c0c960b71a7020d9f60077f6af931a8bbf590da0223dacf75c7af0155565b613dc8565b816001600160a01b0316836001600160a01b031614613dc857613dc88382613eb8565b6001600160a01b038216613ddf57610f6981613f55565b826001600160a01b0316826001600160a01b031614610f6957610f69828261402e565b6000613e0d82611e0b565b9050613e1b8160008461399c565b613e26600083612c27565b6001600160a01b0381166000908152600360205260408120805460019290613e4f908490614902565b909155505060008281526002602052604080822080546001600160a01b0319169055518391906001600160a01b038416907fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef908390a45050565b60606115098484600085614072565b60006001613ec584611fdd565b613ecf9190614902565b600083815260086020526040902054909150808214613f22576001600160a01b03841660009081526007602090815260408083208584528252808320548484528184208190558352600890915290208190555b5060009182526008602090815260408084208490556001600160a01b039094168352600781528383209183525290812055565b600954600090613f6790600190614902565b6000838152600a602052604081205460098054939450909284908110613f9d57634e487b7160e01b600052603260045260246000fd5b906000526020600020015490508060098381548110613fcc57634e487b7160e01b600052603260045260246000fd5b6000918252602080832090910192909255828152600a9091526040808220849055858252812055600980548061401257634e487b7160e01b600052603160045260246000fd5b6001900381819060005260206000200160009055905550505050565b600061403983611fdd565b6001600160a01b039093166000908152600760209081526040808320868452825280832085905593825260089052919091209190915550565b6060824710156140d35760405162461bcd60e51b815260206004820152602660248201527f416464726573733a20696e73756666696369656e742062616c616e636520666f6044820152651c8818d85b1b60d21b6064820152608401610e33565b843b6141215760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e74726163740000006044820152606401610e33565b600080866001600160a01b0316858760405161413d919061464e565b60006040518083038185875af1925050503d806000811461417a576040519150601f19603f3d011682016040523d82523d6000602084013e61417f565b606091505b509150915061418f82828661419a565b979650505050505050565b606083156141a95750816125d5565b8251156141b95782518084602001fd5b8160405162461bcd60e51b8152600401610e3391906146a7565b8280546141df90614945565b90600052602060002090601f0160209004810192826142015760008555614247565b82601f1061421a57805160ff1916838001178555614247565b82800160010185558215614247579182015b8281111561424757825182559160200191906001019061422c565b5061425392915061428d565b5090565b50805461426390614945565b6000825580601f10614273575050565b601f01602090049060005260206000209081019061299891905b5b80821115614253576000815560010161428e565b60008083601f8401126142b3578182fd5b50813567ffffffffffffffff8111156142ca578182fd5b6020830191508360208260051b85010111156142e557600080fd5b9250929050565b6000602082840312156142fd578081fd5b81356125d5816149a6565b6000806040838503121561431a578081fd5b8235614325816149a6565b91506020830135614335816149a6565b809150509250929050565b600080600060608486031215614354578081fd5b833561435f816149a6565b9250602084013561436f816149a6565b929592945050506040919091013590565b60008060008060808587031215614395578081fd5b84356143a0816149a6565b935060208501356143b0816149a6565b925060408501359150606085013567ffffffffffffffff808211156143d3578283fd5b818701915087601f8301126143e6578283fd5b8135818111156143f8576143f8614990565b604051601f8201601f19908116603f0116810190838211818310171561442057614420614990565b816040528281528a6020848701011115614438578586fd5b82602086016020830137918201602001949094529598949750929550505050565b6000806040838503121561446b578182fd5b8235614476816149a6565b91506020830135614335816149bb565b60008060408385031215614498578182fd5b82356144a3816149a6565b946020939093013593505050565b600080604083850312156144c3578182fd5b82516144ce816149a6565b6020939093015192949293505050565b600080600080604085870312156144f3578384fd5b843567ffffffffffffffff8082111561450a578586fd5b614516888389016142a2565b9096509450602087013591508082111561452e578384fd5b5061453b878288016142a2565b95989497509550505050565b600060208284031215614558578081fd5b81516125d5816149bb565b600060208284031215614574578081fd5b81356125d5816149c9565b600060208284031215614590578081fd5b81516125d5816149c9565b6000806040838503121561431a578182fd5b6000602082840312156145be578081fd5b5035919050565b6000602082840312156145d6578081fd5b5051919050565b600080604083850312156145ef578182fd5b823591506020830135614335816149a6565b60008060408385031215614613578182fd5b50508035926020909101359150565b6000815180845261463a816020860160208601614919565b601f01601f19169290920160200192915050565b60008251614660818460208701614919565b9190910192915050565b6001600160a01b038581168252841660208201526040810183905260806060820181905260009061469d90830184614622565b9695505050505050565b6020815260006125d56020830184614622565b60208082526032908201527f4552433732313a207472616e7366657220746f206e6f6e20455243373231526560408201527131b2b4bb32b91034b6b83632b6b2b73a32b960711b606082015260800190565b60208082526026908201527f5061796d656e7453706c69747465723a206163636f756e7420686173206e6f2060408201526573686172657360d01b606082015260800190565b60208082526008908201526727a31d229698181b60c11b604082015260600190565b6020808252602b908201527f5061796d656e7453706c69747465723a206163636f756e74206973206e6f742060408201526a191d59481c185e5b595b9d60aa1b606082015260800190565b6020808252600890820152674f463a452d30303960c01b604082015260600190565b60208082526008908201526704f463a452d3031360c41b604082015260600190565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b60208082526031908201527f4552433732313a207472616e736665722063616c6c6572206973206e6f74206f6040820152701ddb995c881b9bdc88185c1c1c9bdd9959607a1b606082015260800190565b6020808252600890820152674f463a452d30303360c01b604082015260600190565b600082198211156148be576148be61497a565b500190565b6000826148de57634e487b7160e01b81526012600452602481fd5b500490565b60008160001904831182151516156148fd576148fd61497a565b500290565b6000828210156149145761491461497a565b500390565b60005b8381101561493457818101518382015260200161491c565b8381111561260e5750506000910152565b600181811c9082168061495957607f821691505b6020821081141561134c57634e487b7160e01b600052602260045260246000fd5b634e487b7160e01b600052601160045260246000fd5b634e487b7160e01b600052604160045260246000fd5b6001600160a01b038116811461299857600080fd5b801515811461299857600080fd5b6001600160e01b03198116811461299857600080fdfea2646970667358221220adc08a0034f7bbe90d480ac5b3a75da507d5d05e0c7575ed853932a7762ed1d764736f6c63430008040033",
+  "deployedBytecode": "0x6080604052600436106103e85760003560e01c80636a62784211610208578063ae9df3d411610118578063d0e30db0116100ab578063e33b7de31161007a578063e33b7de314610bdc578063e985e9c514610bf1578063f2fde38b14610c3a578063f3fef3a314610c5a578063fdf8967314610c6d57600080fd5b8063d0e30db014610b76578063d684beff14610b7e578063d79779b214610b93578063d96a094a14610bc957600080fd5b8063bcc1c53f116100e7578063bcc1c53f14610aeb578063c4e41b2214610b0b578063c87b56dd14610b20578063ce7c2ac214610b4057600080fd5b8063ae9df3d414610a5e578063b34c8caf14610a7e578063b88d4fde14610aab578063bbf85e8014610acb57600080fd5b80638b83209b1161019b5780639852595c1161016a5780639852595c146109a8578063a22cb465146109de578063a2606334146109fe578063a7041d7a14610a1e578063ac4b4a1014610a3e57600080fd5b80638b83209b146109355780638c7ea24b146109555780638da5cb5b1461097557806395d89b411461099357600080fd5b80637deb6025116101d75780637deb6025146108cd578063814a76fe146108e05780638417b47f146109005780638859e91f1461092057600080fd5b80636a627842146108655780636f8b44b01461087857806370a0823114610898578063715018a6146108b857600080fd5b806335db70b51161030357806348b750441161029657806359aa03aa1161026557806359aa03aa146107d55780635c975abb146107f55780635f0112011461080f57806363167ced1461082f5780636352211e1461084557600080fd5b806348b750441461074a5780634c0f38c21461076a5780634f6ccce71461077f578063589a17431461079f57600080fd5b806342966c68116102d257806342966c68146106e1578063438ea94a1461070157806347d91e031461072157806347e7ef241461073757600080fd5b806335db70b5146106505780633e48d88f14610666578063406072a91461067b57806342842e0e146106c157600080fd5b806318eef3951161037b57806323b872dd1161034a57806323b872dd146105be5780632a55205a146105de5780632e1a7d4d1461061d5780632f745c591461063057600080fd5b806318eef3951461053c57806318fbcdb314610569578063191655871461057e5780631e2f73b11461059e57600080fd5b8063095ea7b3116103b7578063095ea7b3146104da5780631249c58b146104fc578063172958941461051257806318160ddd1461052757600080fd5b806301ffc9a71461043657806303ee438c1461046b57806306fdde031461048d578063081812fc146104a257600080fd5b36610431577f6ef95f06320e7a25a04a175ca677b7052bdd97131872c2192525a629f51be77033604080516001600160a01b0390921682523460208301520160405180910390a1005b600080fd5b34801561044257600080fd5b50610456610451366004614563565b610c8d565b60405190151581526020015b60405180910390f35b34801561047757600080fd5b50610480610c9e565b60405161046291906146a7565b34801561049957600080fd5b50610480610d2c565b3480156104ae57600080fd5b506104c26104bd3660046145ad565b610dbe565b6040516001600160a01b039091168152602001610462565b3480156104e657600080fd5b506104fa6104f5366004614486565b610e58565b005b610504610f6e565b604051908152602001610462565b34801561051e57600080fd5b50600e54610504565b34801561053357600080fd5b50600954610504565b34801561054857600080fd5b506105046105573660046145ad565b60009081526018602052604090205490565b34801561057557600080fd5b50601f54610504565b34801561058a57600080fd5b506104fa6105993660046142ec565b610fde565b3480156105aa57600080fd5b50601b546104c2906001600160a01b031681565b3480156105ca57600080fd5b506104fa6105d9366004614340565b611120565b3480156105ea57600080fd5b506105fe6105f9366004614601565b611152565b604080516001600160a01b039093168352602083019190915201610462565b61050461062b3660046145ad565b6111a7565b34801561063c57600080fd5b5061050461064b366004614486565b611352565b34801561065c57600080fd5b50610504601d5481565b34801561067257600080fd5b50600f54610504565b34801561068757600080fd5b5061050461069636600461459b565b6001600160a01b03918216600090815260146020908152604080832093909416825291909152205490565b3480156106cd57600080fd5b506104fa6106dc366004614340565b6113e8565b3480156106ed57600080fd5b506104fa6106fc3660046145ad565b611403565b34801561070d57600080fd5b5061050461071c366004614486565b611459565b34801561072d57600080fd5b50610504601f5481565b6104fa610745366004614486565b611511565b34801561075657600080fd5b506104fa61076536600461459b565b611760565b34801561077657600080fd5b50601c54610504565b34801561078b57600080fd5b5061050461079a3660046145ad565b611980565b3480156107ab57600080fd5b506104c26107ba3660046145ad565b6000908152601760205260409020546001600160a01b031690565b3480156107e157600080fd5b506104fa6107f03660046144de565b611a21565b34801561080157600080fd5b506020546104569060ff1681565b34801561081b57600080fd5b506104fa61082a3660046142ec565b611d39565b34801561083b57600080fd5b50610504601e5481565b34801561085157600080fd5b506104c26108603660046145ad565b611e0b565b6105046108733660046142ec565b611e82565b34801561088457600080fd5b506104fa6108933660046145ad565b611f80565b3480156108a457600080fd5b506105046108b33660046142ec565b611fdd565b3480156108c457600080fd5b506104fa612064565b6104566108db3660046145dd565b61209a565b3480156108ec57600080fd5b506104fa6108fb366004614601565b612196565b34801561090c57600080fd5b506104fa61091b3660046145ad565b6121e9565b34801561092c57600080fd5b50601e54610504565b34801561094157600080fd5b506104c26109503660046145ad565b612246565b34801561096157600080fd5b506104fa610970366004614486565b612284565b34801561098157600080fd5b50600c546001600160a01b03166104c2565b34801561099f57600080fd5b50610480612365565b3480156109b457600080fd5b506105046109c33660046142ec565b6001600160a01b031660009081526011602052604090205490565b3480156109ea57600080fd5b506104fa6109f9366004614459565b612374565b348015610a0a57600080fd5b506104fa610a193660046145ad565b61237f565b348015610a2a57600080fd5b506104fa610a393660046145ad565b6123fe565b348015610a4a57600080fd5b506019546104c2906001600160a01b031681565b348015610a6a57600080fd5b50610504610a79366004614340565b612519565b348015610a8a57600080fd5b50610504610a993660046142ec565b60106020526000908152604090205481565b348015610ab757600080fd5b506104fa610ac6366004614380565b6125dc565b348015610ad757600080fd5b506104fa610ae63660046142ec565b612614565b348015610af757600080fd5b50601a546104c2906001600160a01b031681565b348015610b1757600080fd5b50610504612688565b348015610b2c57600080fd5b50610480610b3b3660046145ad565b612693565b348015610b4c57600080fd5b50610504610b5b3660046142ec565b6001600160a01b031660009081526010602052604090205490565b6104fa6127a4565b348015610b8a57600080fd5b506104fa612881565b348015610b9f57600080fd5b50610504610bae3660046142ec565b6001600160a01b031660009081526013602052604090205490565b610456610bd73660046145ad565b6128f4565b348015610be857600080fd5b50600d54610504565b348015610bfd57600080fd5b50610456610c0c366004614308565b6001600160a01b03918216600090815260056020908152604080832093909416825291909152205460ff1690565b348015610c4657600080fd5b506104fa610c553660046142ec565b612900565b610504610c68366004614486565b61299b565b348015610c7957600080fd5b506104fa610c883660046145ad565b612b83565b6000610c9882612c02565b92915050565b60218054610cab90614945565b80601f0160208091040260200160405190810160405280929190818152602001828054610cd790614945565b8015610d245780601f10610cf957610100808354040283529160200191610d24565b820191906000526020600020905b815481529060010190602001808311610d0757829003601f168201915b505050505081565b606060008054610d3b90614945565b80601f0160208091040260200160405190810160405280929190818152602001828054610d6790614945565b8015610db45780601f10610d8957610100808354040283529160200191610db4565b820191906000526020600020905b815481529060010190602001808311610d9757829003601f168201915b5050505050905090565b6000818152600260205260408120546001600160a01b0316610e3c5760405162461bcd60e51b815260206004820152602c60248201527f4552433732313a20617070726f76656420717565727920666f72206e6f6e657860448201526b34b9ba32b73a103a37b5b2b760a11b60648201526084015b60405180910390fd5b506000908152600460205260409020546001600160a01b031690565b6000610e6382611e0b565b9050806001600160a01b0316836001600160a01b03161415610ed15760405162461bcd60e51b815260206004820152602160248201527f4552433732313a20617070726f76616c20746f2063757272656e74206f776e656044820152603960f91b6064820152608401610e33565b336001600160a01b0382161480610eed5750610eed8133610c0c565b610f5f5760405162461bcd60e51b815260206004820152603860248201527f4552433732313a20617070726f76652063616c6c6572206973206e6f74206f7760448201527f6e6572206e6f7220617070726f76656420666f7220616c6c00000000000000006064820152608401610e33565b610f698383612c27565b505050565b60205460009060ff1615610f945760405162461bcd60e51b8152600401610e33906147bf565b601d54341015610fd15760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303160c01b6044820152606401610e33565b610fd9612c95565b905090565b6001600160a01b0381166000908152601060205260409020546110135760405162461bcd60e51b8152600401610e339061470c565b6000600f54600e546110259190614902565b600d5461103290476148ab565b61103c9190614902565b905060006110698383611064866001600160a01b031660009081526011602052604090205490565b612da0565b9050806110885760405162461bcd60e51b8152600401610e3390614774565b6001600160a01b038316600090815260116020526040812080548392906110b09084906148ab565b9250508190555080600d60008282546110c991906148ab565b909155506110d990508382612ddc565b604080516001600160a01b0385168152602081018390527fdf20fd1e76bc69d672e4814fafb2c449bba3a5369d8359adf9e05e6fde87b056910160405180910390a1505050565b61112b335b82612ef5565b6111475760405162461bcd60e51b8152600401610e3390614838565b610f69838383612fe8565b60408051808201909152600b546001600160a01b038116808352600160a01b90910462ffffff166020830181905290916000916127109061119390866148e3565b61119d91906148c3565b9150509250929050565b6000816111b333611125565b6111cf5760405162461bcd60e51b8152600401610e33906147e1565b6019546001600160a01b03166111f75760405162461bcd60e51b8152600401610e3390614889565b600061120284611e0b565b6019546040516321c754a560e11b8152306004820152602481018790529192506000916001600160a01b039091169063438ea94a9060440160206040518083038186803b15801561125257600080fd5b505afa158015611266573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061128a91906145c5565b905061129f6001600160a01b03831682612ddc565b80600f60008282546112b191906148ab565b9091555050601954604051630e6621ff60e11b815260006004820152602481018790526001600160a01b0390911690631ccc43fe90604401600060405180830381600087803b15801561130357600080fd5b505af1158015611317573d6000803e3d6000fd5b50506040518392508791507fd2e9df57c00b23ba7ee3ed404df528700b0f0990b7292602d48fb3b9764e507690600090a39250505b50919050565b600061135d83611fdd565b82106113bf5760405162461bcd60e51b815260206004820152602b60248201527f455243373231456e756d657261626c653a206f776e657220696e646578206f7560448201526a74206f6620626f756e647360a81b6064820152608401610e33565b506001600160a01b03919091166000908152600760209081526040808320938352929052205490565b610f69838383604051806020016040528060008152506125dc565b8061140d33611125565b6114295760405162461bcd60e51b8152600401610e33906147e1565b60205460ff161561144c5760405162461bcd60e51b8152600401610e33906147bf565b61145582613193565b5050565b6019546000906001600160a01b03166114845760405162461bcd60e51b8152600401610e3390614889565b6019546040516321c754a560e11b81526001600160a01b03858116600483015260248201859052600092169063438ea94a9060440160206040518083038186803b1580156114d157600080fd5b505afa1580156114e5573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061150991906145c5565b949350505050565b604051636eb1769f60e11b81523360048201523060248201526000906001600160a01b0384169063dd62ed3e9060440160206040518083038186803b15801561155957600080fd5b505afa15801561156d573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061159191906145c5565b9050600061159e60095490565b6019549091506001600160a01b03166115c95760405162461bcd60e51b8152600401610e3390614889565b828210156116045760405162461bcd60e51b815260206004820152600860248201526713d18e914b4c0c0d60c21b6044820152606401610e33565b6040516323b872dd60e01b8152336004820152306024820152604481018490526001600160a01b038516906323b872dd90606401602060405180830381600087803b15801561165257600080fd5b505af1158015611666573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061168a9190614547565b5060195460405162f9874d60e31b81526001600160a01b0386811660048301526024820186905260448201849052909116906307cc3a6890606401600060405180830381600087803b1580156116df57600080fd5b505af11580156116f3573d6000803e3d6000fd5b505050506001600160a01b0384166000908152601560205260408120805485929061171f9084906148ab565b909155505060405134906001600160a01b038616907f8d5b2df7eba39b5e2a616e9c89e0c253c36b92c638f32ad4f4e2bedc0ee5ba7d90600090a350505050565b6001600160a01b0381166000908152601060205260409020546117955760405162461bcd60e51b8152600401610e339061470c565b6001600160a01b03821660009081526016602090815260408083205460159092528220546117c39190614902565b6001600160a01b0384166000908152601360205260409020546040516370a0823160e01b81523060048201526001600160a01b038616906370a082319060240160206040518083038186803b15801561181b57600080fd5b505afa15801561182f573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061185391906145c5565b61185d91906148ab565b6118679190614902565b905060006118a0838361106487876001600160a01b03918216600090815260146020908152604080832093909416825291909152205490565b9050806118bf5760405162461bcd60e51b8152600401610e3390614774565b6001600160a01b038085166000908152601460209081526040808320938716835292905290812080548392906118f69084906148ab565b90915550506001600160a01b038416600090815260136020526040812080548392906119239084906148ab565b90915550611934905084848361319c565b604080516001600160a01b038581168252602082018490528616917f3be5b7a71e84ed12875d241991c70855ac5817d847039e17a9d895c1ceb0f18a910160405180910390a250505050565b600061198b60095490565b82106119ee5760405162461bcd60e51b815260206004820152602c60248201527f455243373231456e756d657261626c653a20676c6f62616c20696e646578206f60448201526b7574206f6620626f756e647360a01b6064820152608401610e33565b60098281548110611a0f57634e487b7160e01b600052603260045260246000fd5b90600052602060002001549050919050565b828114611a8b5760405162461bcd60e51b815260206004820152603260248201527f5061796d656e7453706c69747465723a2070617965657320616e6420736861726044820152710cae640d8cadccee8d040dad2e6dac2e8c6d60731b6064820152608401610e33565b82611ad85760405162461bcd60e51b815260206004820152601a60248201527f5061796d656e7453706c69747465723a206e6f207061796565730000000000006044820152606401610e33565b60005b83811015611d3257828282818110611b0357634e487b7160e01b600052603260045260246000fd5b9050602002013560106000336001600160a01b03166001600160a01b03168152602001908152602001600020541015611ba6576040805162461bcd60e51b81526020600482015260248101919091527f5061796d656e7453706c69747465723a206163636f756e7420646f6573206e6f60448201527f74206861766520656e6f7567682073686172657320746f20616c6c6f636174656064820152608401610e33565b828282818110611bc657634e487b7160e01b600052603260045260246000fd5b33600090815260106020908152604090912054611bea949190920201359150614902565b3360009081526010602081905260408220929092559081878785818110611c2157634e487b7160e01b600052603260045260246000fd5b9050602002016020810190611c3691906142ec565b6001600160a01b03166001600160a01b03168152602001908152602001600020541115611cc657611cc1858583818110611c8057634e487b7160e01b600052603260045260246000fd5b9050602002016020810190611c9591906142ec565b848484818110611cb557634e487b7160e01b600052603260045260246000fd5b905060200201356131ee565b611d2a565b611d2a858583818110611ce957634e487b7160e01b600052603260045260246000fd5b9050602002016020810190611cfe91906142ec565b848484818110611d1e57634e487b7160e01b600052603260045260246000fd5b90506020020135613232565b600101611adb565b5050505050565b600c546001600160a01b03163314611d635760405162461bcd60e51b8152600401610e3390614803565b601980546001600160a01b0319166001600160a01b0383169081179091556040805163df2845b560e01b8152905163df2845b59160048082019260009290919082900301818387803b158015611db857600080fd5b505af1158015611dcc573d6000803e3d6000fd5b50506019546040516001600160a01b0390911692507f7947799a5d3281fff4a4457606b1aaa700d7ddecbe5b6143ff45b6c9866a8cc29150600090a250565b6000818152600260205260408120546001600160a01b031680610c985760405162461bcd60e51b815260206004820152602960248201527f4552433732313a206f776e657220717565727920666f72206e6f6e657869737460448201526832b73a103a37b5b2b760b91b6064820152608401610e33565b60205460009060ff1615611ea85760405162461bcd60e51b8152600401610e33906147bf565b601d54341015611ee55760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303160c01b6044820152606401610e33565b601e5415611f78576000611efb601e54346133fe565b9050611f106001600160a01b03841682612ddc565b604051667072696d61727960c81b81526001600160a01b0384169060070160405180910390207f522c39d7156b7dd9419c7853d069ac52655fb23c5ec017f319477ad7bef213aa611f6060095490565b604080519182523460208301520160405180910390a3505b610c98612c95565b600c546001600160a01b03163314611faa5760405162461bcd60e51b8152600401610e3390614803565b601c81905560405181907facc639f1ff310faf48650d02a82bd24c924e45a5050fc931245096ac57c309d990600090a250565b60006001600160a01b0382166120485760405162461bcd60e51b815260206004820152602a60248201527f4552433732313a2062616c616e636520717565727920666f7220746865207a65604482015269726f206164647265737360b01b6064820152608401610e33565b506001600160a01b031660009081526003602052604090205490565b600c546001600160a01b0316331461208e5760405162461bcd60e51b8152600401610e3390614803565b6120986000613416565b565b60006001600160a01b0382166120dd5760405162461bcd60e51b815260206004820152600860248201526727a31d229698181960c11b6044820152606401610e33565b600083815260186020526040812054601f549091906120fc90836133fe565b601f549091501561217a5761211a6001600160a01b03851682612ddc565b604051687365636f6e6461727960b81b81526001600160a01b0385169060090160408051918290038220888352346020840152917f522c39d7156b7dd9419c7853d069ac52655fb23c5ec017f319477ad7bef213aa910160405180910390a35b61218d856121883484613468565b613474565b95945050505050565b60205460ff16156121b95760405162461bcd60e51b8152600401610e33906147bf565b816121c333611125565b6121df5760405162461bcd60e51b8152600401610e33906147e1565b610f698383613690565b600c546001600160a01b031633146122135760405162461bcd60e51b8152600401610e3390614803565b601d81905560405181907f02dd4e125a287edc7a6a887552dc7be35f4fdabe8afd6ae78f98b448d4e1a86690600090a250565b60006012828154811061226957634e487b7160e01b600052603260045260246000fd5b6000918252602090912001546001600160a01b031692915050565b600c546001600160a01b031633146122ae5760405162461bcd60e51b8152600401610e3390614803565b600081116122e95760405162461bcd60e51b815260206004820152600860248201526713d18e914b4c0c0d60c21b6044820152606401610e33565b6001600160a01b03821661232a5760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303560c01b6044820152606401610e33565b61233482826136e1565b604051819030907f908669f35f6fb3977a956ba70597841fe541d1e8491ca3c025161e258d3bfdb690600090a35050565b606060018054610d3b90614945565b61145533838361377d565b600c546001600160a01b031633146123a95760405162461bcd60e51b8152600401610e3390614803565b6127108111156123cb5760405162461bcd60e51b8152600401610e3390614752565b601f81905560405181907f905c2604b04c9fa2b09e05ab34ccae93abf21f5edd19a139c406fe9398f752a090600090a250565b600c546001600160a01b031633146124285760405162461bcd60e51b8152600401610e3390614803565b61271081111561244a5760405162461bcd60e51b8152600401610e3390614752565b601a546001600160a01b031661248d5760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303760c01b6044820152606401610e33565b601a5460405163074ae54d60e01b8152600481018390526001600160a01b039091169063074ae54d90602401600060405180830381600087803b1580156124d357600080fd5b505af11580156124e7573d6000803e3d6000fd5b50506040518392507f67c41861347f4f7588ff0bd41c40943750a52c35859b99dac7d30beda950088c9150600090a250565b6019546000906001600160a01b03166125445760405162461bcd60e51b8152600401610e3390614889565b601954604051632ba77cf560e21b81526001600160a01b038681166004830152858116602483015260448201859052600092169063ae9df3d49060640160206040518083038186803b15801561259957600080fd5b505afa1580156125ad573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906125d191906145c5565b9150505b9392505050565b6125e63383612ef5565b6126025760405162461bcd60e51b8152600401610e3390614838565b61260e8484848461384c565b50505050565b600c546001600160a01b0316331461263e5760405162461bcd60e51b8152600401610e3390614803565b601a80546001600160a01b0319166001600160a01b0383169081179091556040517f5db3fb7335b6ec1dfcfd94d09bc1904829d1b8fdba0dc0ad6ee68d71650652ae90600090a250565b6000610fd960095490565b6000818152600260205260409020546060906001600160a01b03166127125760405162461bcd60e51b815260206004820152602f60248201527f4552433732314d657461646174613a2055524920717565727920666f72206e6f60448201526e3732bc34b9ba32b73a103a37b5b2b760891b6064820152608401610e33565b6021805461271f90614945565b80601f016020809104026020016040519081016040528092919081815260200182805461274b90614945565b80156127985780601f1061276d57610100808354040283529160200191612798565b820191906000526020600020905b81548152906001019060200180831161277b57829003601f168201915b50505050509050919050565b6019546001600160a01b03166127cc5760405162461bcd60e51b8152600401610e3390614889565b60006127d760095490565b60195460405163a64271f160e01b8152346004820152602481018390529192506001600160a01b03169063a64271f190604401600060405180830381600087803b15801561282457600080fd5b505af1158015612838573d6000803e3d6000fd5b5050505034600e600082825461284e91906148ab565b909155505060405134907f3903d05344bfbe173a5084aa4d3a99187eff3f7bfb3db786c814e7eddd9b3cd590600090a250565b600c546001600160a01b031633146128ab5760405162461bcd60e51b8152600401610e3390614803565b6020805460ff8082161560ff199092168217835560405191161581527fa9bfed3d98385b3777389e321dbde773cf7d335fa604fefbae3dca93564f5586910160405180910390a1565b6000610c988234613474565b600c546001600160a01b0316331461292a5760405162461bcd60e51b8152600401610e3390614803565b6001600160a01b03811661298f5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b6064820152608401610e33565b61299881613416565b50565b6000816129a733611125565b6129c35760405162461bcd60e51b8152600401610e33906147e1565b6019546001600160a01b03166129eb5760405162461bcd60e51b8152600401610e3390614889565b60006129f684611e0b565b601954604051632ba77cf560e21b81526001600160a01b038881166004830152306024830152604482018890529293506000929091169063ae9df3d49060640160206040518083038186803b158015612a4e57600080fd5b505afa158015612a62573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612a8691906145c5565b6001600160a01b038716600090815260166020526040812080549293508392909190612ab39084906148ab565b909155505060195460405163fdb047b160e01b81526001600160a01b03888116600483015260006024830152604482018890529091169063fdb047b190606401600060405180830381600087803b158015612b0d57600080fd5b505af1158015612b21573d6000803e3d6000fd5b50612b3a925050506001600160a01b038716838361319c565b6040516001600160a01b0387168152819086907f12ff21bbdebdfd7045c78e9aa73dc7777831b172e9097bc41bedd40f841c0afd9060200160405180910390a395945050505050565b600c546001600160a01b03163314612bad5760405162461bcd60e51b8152600401610e3390614803565b612710811115612bcf5760405162461bcd60e51b8152600401610e3390614752565b601e81905560405181907fb27a19d53c022a09a344f42378e7d232d66b643564218cbfc93c98c93a2bc7af90600090a250565b60006001600160e01b0319821663780e9d6360e01b1480610c985750610c988261387f565b600081815260046020526040902080546001600160a01b0319166001600160a01b0384169081179091558190612c5c82611e0b565b6001600160a01b03167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92560405160405180910390a45050565b6000612ca060095490565b9050612cbc3382604051806020016040528060008152506138cf565b600081815260176020526040902080546001600160a01b0319163317905560218054612d70918391612ced90614945565b80601f0160208091040260200160405190810160405280929190818152602001828054612d1990614945565b8015612d665780601f10612d3b57610100808354040283529160200191612d66565b820191906000526020600020905b815481529060010190602001808311612d4957829003601f168201915b5050505050613902565b604051339082907fb9203d657e9c0ec8274c818292ab0f58b04e1970050716891770eb1bab5d655e90600090a390565b6001600160a01b0383166000908152601060205260408120548290606490612dc890866148e3565b612dd291906148c3565b6115099190614902565b80471015612e2c5760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a20696e73756666696369656e742062616c616e63650000006044820152606401610e33565b6000826001600160a01b03168260405160006040518083038185875af1925050503d8060008114612e79576040519150601f19603f3d011682016040523d82523d6000602084013e612e7e565b606091505b5050905080610f695760405162461bcd60e51b815260206004820152603a60248201527f416464726573733a20756e61626c6520746f2073656e642076616c75652c207260448201527f6563697069656e74206d617920686176652072657665727465640000000000006064820152608401610e33565b6000818152600260205260408120546001600160a01b0316612f6e5760405162461bcd60e51b815260206004820152602c60248201527f4552433732313a206f70657261746f7220717565727920666f72206e6f6e657860448201526b34b9ba32b73a103a37b5b2b760a11b6064820152608401610e33565b6000612f7983611e0b565b9050806001600160a01b0316846001600160a01b03161480612fb45750836001600160a01b0316612fa984610dbe565b6001600160a01b0316145b8061150957506001600160a01b0380821660009081526005602090815260408083209388168352929052205460ff16611509565b826001600160a01b0316612ffb82611e0b565b6001600160a01b0316146130635760405162461bcd60e51b815260206004820152602960248201527f4552433732313a207472616e73666572206f6620746f6b656e2074686174206960448201526839903737ba1037bbb760b91b6064820152608401610e33565b6001600160a01b0382166130c55760405162461bcd60e51b8152602060048201526024808201527f4552433732313a207472616e7366657220746f20746865207a65726f206164646044820152637265737360e01b6064820152608401610e33565b6130d083838361399c565b6130db600082612c27565b6001600160a01b0383166000908152600360205260408120805460019290613104908490614902565b90915550506001600160a01b03821660009081526003602052604081208054600192906131329084906148ab565b909155505060008181526002602052604080822080546001600160a01b0319166001600160a01b0386811691821790925591518493918716917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef91a4505050565b612998816139a7565b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180516001600160e01b031663a9059cbb60e01b179052610f699084906139e7565b6001600160a01b0382166000908152601060205260409020546132129082906148ab565b6001600160a01b0390921660009081526010602052604090209190915550565b6001600160a01b03821661329d5760405162461bcd60e51b815260206004820152602c60248201527f5061796d656e7453706c69747465723a206163636f756e74206973207468652060448201526b7a65726f206164647265737360a01b6064820152608401610e33565b600081116132ed5760405162461bcd60e51b815260206004820152601d60248201527f5061796d656e7453706c69747465723a207368617265732061726520300000006044820152606401610e33565b6001600160a01b038216600090815260106020526040902054156133675760405162461bcd60e51b815260206004820152602b60248201527f5061796d656e7453706c69747465723a206163636f756e7420616c726561647960448201526a206861732073686172657360a81b6064820152608401610e33565b60128054600181019091557fbb8a6a4669ba250d26cd7a459eca9d215f8307e33aebe50379bc5a3617ec34440180546001600160a01b0319166001600160a01b038416908117909155600081815260106020908152604091829020849055815192835282018390527f40c340f65e17194d14ddddb073d3c9f888e3cb52b5aae0c6c7706b4fbc905fac910160405180910390a15050565b60006125d56127106134108486613ab9565b90613ac5565b600c80546001600160a01b038381166001600160a01b0319831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e090600090a35050565b60006125d58284614902565b600082815260186020526040812054806134bb5760405162461bcd60e51b81526020600482015260086024820152674f463a452d30303760c01b6044820152606401610e33565b808310156134f65760405162461bcd60e51b815260206004820152600860248201526709e8c748a5a6060760c31b6044820152606401610e33565b600061350185611e0b565b905060003360405163152a902d60e11b81526000600482018190526024820186905291925081903090632a55205a90604401604080518083038186803b15801561354a57600080fd5b505afa15801561355e573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061358291906144b1565b601a5491935091506001600160a01b0316156135b357601a546135ae906001600160a01b031682612ddc565b613603565b8015613603576135cc6001600160a01b03831682612ddc565b60405181906001600160a01b038416907fbc86de696edc3350c664d50abf25f24e7e1251f1469ad925b25fe36927270d4390600090a35b6136206136108683613468565b6001600160a01b03861690612ddc565b826001600160a01b0316846001600160a01b0316897f23f50d55776d8003622a982ade45a6c7f083116c8dbbcd980f59942f440badb18860405161366691815260200190565b60405180910390a461367785613ad1565b61368284848a612fe8565b506001979650505050505050565b600082815260186020526040908190208290555182907fe23ea816dce6d7f5c0b85cbd597e7c3b97b2453791152c0b94e5e5c5f314d2f0906136d59084815260200190565b60405180910390a25050565b6127108111156137335760405162461bcd60e51b815260206004820152601a60248201527f45524332393831526f79616c746965733a20546f6f20686967680000000000006044820152606401610e33565b604080518082019091526001600160a01b0390921680835262ffffff9091166020909201829052600b8054600160a01b9093026001600160b81b0319909316909117919091179055565b816001600160a01b0316836001600160a01b031614156137df5760405162461bcd60e51b815260206004820152601960248201527f4552433732313a20617070726f766520746f2063616c6c6572000000000000006044820152606401610e33565b6001600160a01b03838116600081815260056020908152604080832094871680845294825291829020805460ff191686151590811790915591519182527f17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31910160405180910390a3505050565b613857848484612fe8565b61386384848484613aef565b61260e5760405162461bcd60e51b8152600401610e33906146ba565b60006001600160e01b031982166380ac58cd60e01b14806138b057506001600160e01b03198216635b5e139f60e01b145b80610c9857506301ffc9a760e01b6001600160e01b0319831614610c98565b6138d98383613bfc565b6138e66000848484613aef565b610f695760405162461bcd60e51b8152600401610e33906146ba565b6000828152600260205260409020546001600160a01b031661397d5760405162461bcd60e51b815260206004820152602e60248201527f45524337323155524953746f726167653a2055524920736574206f66206e6f6e60448201526d32bc34b9ba32b73a103a37b5b2b760911b6064820152608401610e33565b60008281526006602090815260409091208251610f69928401906141d3565b610f69838383613d4a565b6139b081613e02565b600081815260066020526040902080546139c990614945565b15905061299857600081815260066020526040812061299891614257565b6000613a3c826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b0316613ea99092919063ffffffff16565b805190915015610f695780806020019051810190613a5a9190614547565b610f695760405162461bcd60e51b815260206004820152602a60248201527f5361666545524332303a204552433230206f7065726174696f6e20646964206e6044820152691bdd081cdd58d8d9595960b21b6064820152608401610e33565b60006125d582846148e3565b60006125d582846148c3565b6000613add3483613468565b90508015611455576114553382612ddc565b60006001600160a01b0384163b15613bf157604051630a85bd0160e11b81526001600160a01b0385169063150b7a0290613b3390339089908890889060040161466a565b602060405180830381600087803b158015613b4d57600080fd5b505af1925050508015613b7d575060408051601f3d908101601f19168201909252613b7a9181019061457f565b60015b613bd7573d808015613bab576040519150601f19603f3d011682016040523d82523d6000602084013e613bb0565b606091505b508051613bcf5760405162461bcd60e51b8152600401610e33906146ba565b805181602001fd5b6001600160e01b031916630a85bd0160e11b149050611509565b506001949350505050565b6001600160a01b038216613c525760405162461bcd60e51b815260206004820181905260248201527f4552433732313a206d696e7420746f20746865207a65726f20616464726573736044820152606401610e33565b6000818152600260205260409020546001600160a01b031615613cb75760405162461bcd60e51b815260206004820152601c60248201527f4552433732313a20746f6b656e20616c7265616479206d696e746564000000006044820152606401610e33565b613cc36000838361399c565b6001600160a01b0382166000908152600360205260408120805460019290613cec9084906148ab565b909155505060008181526002602052604080822080546001600160a01b0319166001600160a01b03861690811790915590518392907fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef908290a45050565b6001600160a01b038316613da557613da081600980546000838152600a60205260408120829055600182018355919091527f6e1540171b6c0c960b71a7020d9f60077f6af931a8bbf590da0223dacf75c7af0155565b613dc8565b816001600160a01b0316836001600160a01b031614613dc857613dc88382613eb8565b6001600160a01b038216613ddf57610f6981613f55565b826001600160a01b0316826001600160a01b031614610f6957610f69828261402e565b6000613e0d82611e0b565b9050613e1b8160008461399c565b613e26600083612c27565b6001600160a01b0381166000908152600360205260408120805460019290613e4f908490614902565b909155505060008281526002602052604080822080546001600160a01b0319169055518391906001600160a01b038416907fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef908390a45050565b60606115098484600085614072565b60006001613ec584611fdd565b613ecf9190614902565b600083815260086020526040902054909150808214613f22576001600160a01b03841660009081526007602090815260408083208584528252808320548484528184208190558352600890915290208190555b5060009182526008602090815260408084208490556001600160a01b039094168352600781528383209183525290812055565b600954600090613f6790600190614902565b6000838152600a602052604081205460098054939450909284908110613f9d57634e487b7160e01b600052603260045260246000fd5b906000526020600020015490508060098381548110613fcc57634e487b7160e01b600052603260045260246000fd5b6000918252602080832090910192909255828152600a9091526040808220849055858252812055600980548061401257634e487b7160e01b600052603160045260246000fd5b6001900381819060005260206000200160009055905550505050565b600061403983611fdd565b6001600160a01b039093166000908152600760209081526040808320868452825280832085905593825260089052919091209190915550565b6060824710156140d35760405162461bcd60e51b815260206004820152602660248201527f416464726573733a20696e73756666696369656e742062616c616e636520666f6044820152651c8818d85b1b60d21b6064820152608401610e33565b843b6141215760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e74726163740000006044820152606401610e33565b600080866001600160a01b0316858760405161413d919061464e565b60006040518083038185875af1925050503d806000811461417a576040519150601f19603f3d011682016040523d82523d6000602084013e61417f565b606091505b509150915061418f82828661419a565b979650505050505050565b606083156141a95750816125d5565b8251156141b95782518084602001fd5b8160405162461bcd60e51b8152600401610e3391906146a7565b8280546141df90614945565b90600052602060002090601f0160209004810192826142015760008555614247565b82601f1061421a57805160ff1916838001178555614247565b82800160010185558215614247579182015b8281111561424757825182559160200191906001019061422c565b5061425392915061428d565b5090565b50805461426390614945565b6000825580601f10614273575050565b601f01602090049060005260206000209081019061299891905b5b80821115614253576000815560010161428e565b60008083601f8401126142b3578182fd5b50813567ffffffffffffffff8111156142ca578182fd5b6020830191508360208260051b85010111156142e557600080fd5b9250929050565b6000602082840312156142fd578081fd5b81356125d5816149a6565b6000806040838503121561431a578081fd5b8235614325816149a6565b91506020830135614335816149a6565b809150509250929050565b600080600060608486031215614354578081fd5b833561435f816149a6565b9250602084013561436f816149a6565b929592945050506040919091013590565b60008060008060808587031215614395578081fd5b84356143a0816149a6565b935060208501356143b0816149a6565b925060408501359150606085013567ffffffffffffffff808211156143d3578283fd5b818701915087601f8301126143e6578283fd5b8135818111156143f8576143f8614990565b604051601f8201601f19908116603f0116810190838211818310171561442057614420614990565b816040528281528a6020848701011115614438578586fd5b82602086016020830137918201602001949094529598949750929550505050565b6000806040838503121561446b578182fd5b8235614476816149a6565b91506020830135614335816149bb565b60008060408385031215614498578182fd5b82356144a3816149a6565b946020939093013593505050565b600080604083850312156144c3578182fd5b82516144ce816149a6565b6020939093015192949293505050565b600080600080604085870312156144f3578384fd5b843567ffffffffffffffff8082111561450a578586fd5b614516888389016142a2565b9096509450602087013591508082111561452e578384fd5b5061453b878288016142a2565b95989497509550505050565b600060208284031215614558578081fd5b81516125d5816149bb565b600060208284031215614574578081fd5b81356125d5816149c9565b600060208284031215614590578081fd5b81516125d5816149c9565b6000806040838503121561431a578182fd5b6000602082840312156145be578081fd5b5035919050565b6000602082840312156145d6578081fd5b5051919050565b600080604083850312156145ef578182fd5b823591506020830135614335816149a6565b60008060408385031215614613578182fd5b50508035926020909101359150565b6000815180845261463a816020860160208601614919565b601f01601f19169290920160200192915050565b60008251614660818460208701614919565b9190910192915050565b6001600160a01b038581168252841660208201526040810183905260806060820181905260009061469d90830184614622565b9695505050505050565b6020815260006125d56020830184614622565b60208082526032908201527f4552433732313a207472616e7366657220746f206e6f6e20455243373231526560408201527131b2b4bb32b91034b6b83632b6b2b73a32b960711b606082015260800190565b60208082526026908201527f5061796d656e7453706c69747465723a206163636f756e7420686173206e6f2060408201526573686172657360d01b606082015260800190565b60208082526008908201526727a31d229698181b60c11b604082015260600190565b6020808252602b908201527f5061796d656e7453706c69747465723a206163636f756e74206973206e6f742060408201526a191d59481c185e5b595b9d60aa1b606082015260800190565b6020808252600890820152674f463a452d30303960c01b604082015260600190565b60208082526008908201526704f463a452d3031360c41b604082015260600190565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b60208082526031908201527f4552433732313a207472616e736665722063616c6c6572206973206e6f74206f6040820152701ddb995c881b9bdc88185c1c1c9bdd9959607a1b606082015260800190565b6020808252600890820152674f463a452d30303360c01b604082015260600190565b600082198211156148be576148be61497a565b500190565b6000826148de57634e487b7160e01b81526012600452602481fd5b500490565b60008160001904831182151516156148fd576148fd61497a565b500290565b6000828210156149145761491461497a565b500390565b60005b8381101561493457818101518382015260200161491c565b8381111561260e5750506000910152565b600181811c9082168061495957607f821691505b6020821081141561134c57634e487b7160e01b600052602260045260246000fd5b634e487b7160e01b600052601160045260246000fd5b634e487b7160e01b600052604160045260246000fd5b6001600160a01b038116811461299857600080fd5b801515811461299857600080fd5b6001600160e01b03198116811461299857600080fdfea2646970667358221220adc08a0034f7bbe90d480ac5b3a75da507d5d05e0c7575ed853932a7762ed1d764736f6c63430008040033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/contracts/OpenFormat.sol
+++ b/contracts/OpenFormat.sol
@@ -256,7 +256,12 @@ contract OpenFormat is
         emit ERC20TotalDepositedAmountUpdated(token, msg.value);
     }
 
-    function withdraw(uint256 tokenId) public payable returns (uint256) {
+    function withdraw(uint256 tokenId)
+        public
+        payable
+        onlyTokenOwnerOrApproved(tokenId)
+        returns (uint256)
+    {
         require(approvedDepositExtension != address(0), "OF:E-003");
 
         address owner = ownerOf(tokenId); // 0
@@ -276,6 +281,7 @@ contract OpenFormat is
     function withdraw(IERC20 token, uint256 tokenId)
         public
         payable
+        onlyTokenOwnerOrApproved(tokenId)
         returns (uint256)
     {
         require(approvedDepositExtension != address(0), "OF:E-003");

--- a/test/OpenFormat.js
+++ b/test/OpenFormat.js
@@ -82,6 +82,38 @@ describe("Open Format", function () {
     expect(contractBalance).to.equal(value);
   });
 
+  it("should only allow holder or approved to withdraw tokens", async () => {
+    // mint NFT
+    await factoryContract["mint()"]({ value: mintingPrice });
+
+    // approve address2 to withdraw
+    await factoryContract.approve(address2.address, 0);
+
+    // deposit some ETH via deposit() function
+    await factoryContract.connect(address1)["deposit()"]({ value });
+
+    // withdraw revShare for token id 0;
+    await expect(
+      factoryContract.connect(address1)["withdraw(uint256)"](0)
+    ).to.be.revertedWith("OF:E-010");
+  });
+
+  it("should allow approved to withdraw tokens", async () => {
+    // mint NFT
+    await factoryContract["mint()"]({ value: mintingPrice });
+
+    // approve address2 to withdraw
+    await factoryContract.approve(address2.address, 0);
+
+    // deposit some ETH via deposit() function
+    await factoryContract.connect(address1)["deposit()"]({ value });
+
+    // withdraw revShare for token id 0;
+    await expect(
+      factoryContract.connect(address2)["withdraw(uint256)"](0)
+    ).to.not.be.revertedWith("OF:E-010");
+  });
+
   it("send correct amount via payment splitter", async () => {
     // send some ETH to contract from address1
     address1.sendTransaction({

--- a/test/OpenFormat.js
+++ b/test/OpenFormat.js
@@ -159,7 +159,7 @@ describe("Open Format", function () {
     const contractBalance = await balance(factoryContract.address);
 
     // withdraw revShare for token id 2;
-    await factoryContract["withdraw(uint256)"](2);
+    await factoryContract.connect(address1)["withdraw(uint256)"](2);
 
     // released funds into owner wallet
     await factoryContract
@@ -173,7 +173,7 @@ describe("Open Format", function () {
     await factoryContract["release(address)"](owner.address);
 
     // withdraw revShare for token id 1;
-    await factoryContract["withdraw(uint256)"](1);
+    await factoryContract.connect(address1)["withdraw(uint256)"](1);
 
     // check correct amount has been released
     const newContractBalance = await balance(factoryContract.address);
@@ -299,20 +299,17 @@ describe("Open Format", function () {
       );
 
       // withdraw revShare for token id 1;
-      await factoryContract["withdraw(address,uint256)"](
-        erc20.address,
-        1
-      );
+      await factoryContract
+        .connect(address1)
+        ["withdraw(address,uint256)"](erc20.address, 1);
       // withdraw revShare for token id 2;
-      await factoryContract["withdraw(address,uint256)"](
-        erc20.address,
-        2
-      );
+      await factoryContract
+        .connect(address1)
+        ["withdraw(address,uint256)"](erc20.address, 2);
       // withdraw revShare for token id 3;
-      await factoryContract["withdraw(address,uint256)"](
-        erc20.address,
-        3
-      );
+      await factoryContract
+        .connect(address1)
+        ["withdraw(address,uint256)"](erc20.address, 3);
 
       // release funds into owner wallet
       await factoryContract["release(address,address)"](
@@ -339,20 +336,17 @@ describe("Open Format", function () {
       const address1Balance = await erc20.balanceOf(address1.address);
 
       // withdraw revShare for token id 1;
-      await factoryContract["withdraw(address,uint256)"](
-        erc20.address,
-        1
-      );
+      await factoryContract
+        .connect(address1)
+        ["withdraw(address,uint256)"](erc20.address, 1);
       // withdraw revShare for token id 2;
-      await factoryContract["withdraw(address,uint256)"](
-        erc20.address,
-        2
-      );
+      await factoryContract
+        .connect(address1)
+        ["withdraw(address,uint256)"](erc20.address, 2);
       // withdraw revShare for token id 3;
-      await factoryContract["withdraw(address,uint256)"](
-        erc20.address,
-        3
-      );
+      await factoryContract
+        .connect(address1)
+        ["withdraw(address,uint256)"](erc20.address, 3);
 
       const newAddress1Balance = await erc20.balanceOf(
         address1.address
@@ -442,10 +436,9 @@ describe("Open Format", function () {
     );
 
     // withdraw revShare for token id 2;
-    await factoryContract["withdraw(address,uint256)"](
-      erc20.address,
-      2
-    );
+    await factoryContract
+      .connect(address1)
+      ["withdraw(address,uint256)"](erc20.address, 2);
 
     // released funds into owner wallet
     await factoryContract
@@ -465,10 +458,9 @@ describe("Open Format", function () {
     );
 
     // withdraw revShare for token id 1;
-    await factoryContract["withdraw(address,uint256)"](
-      erc20.address,
-      1
-    );
+    await factoryContract
+      .connect(address1)
+      ["withdraw(address,uint256)"](erc20.address, 1);
 
     // check correct amount has been released
     const newContractBalance = await erc20.balanceOf(


### PR DESCRIPTION
Currently, anyone can withdraw tokens on behalf of any token holder. This is not ideal as anyone could completely devalue an NFT without the holders permission. This PR add the `onlyTokenOwnerOrApproved` modifier. This means only the owner, or an approved address (via the [`approve()`](https://docs.openzeppelin.com/contracts/2.x/api/token/erc721#ERC721-approve-address-uint256-function)) function can withdraw any native or ERC20 tokens.