### PR TITLE
Fix: Prevent over minting

### DIFF
--- a/contracts/OpenFormat.sol
+++ b/contracts/OpenFormat.sol
@@ -179,6 +179,7 @@ contract OpenFormat is
         returns (uint256 newTokenId)
     {
         require(msg.value >= mintingPrice, "OF:E-001");
+        require(totalSupply() < maxSupply, "OF:E-012");
 
         if (approvedMintingExtension != address(0)) {
             IMintingManager(approvedMintingExtension).mint(msg.sender);
@@ -215,6 +216,7 @@ contract OpenFormat is
         returns (uint256 newTokenId)
     {
         require(msg.value >= mintingPrice, "OF:E-001");
+        require(totalSupply() < maxSupply, "OF:E-012");
 
         if (primaryCommissionPct > 0) {
             uint256 amount = _calculatePercentage(
@@ -338,12 +340,11 @@ contract OpenFormat is
         whenRevShare
         returns (uint256)
     {
-    
         address owner = ownerOf(tokenId);
         uint256 amount = IRevShareManager(approvedRevShareExtension)
             .getSingleTokenBalance(address(this), tokenId);
 
-        require(amount > 0, "OF:E-011" );
+        require(amount > 0, "OF:E-011");
 
         payable(owner).sendValue(amount);
         IRevShareManager(approvedRevShareExtension).updateHolderBalanceETH(
@@ -372,7 +373,7 @@ contract OpenFormat is
         uint256 amount = IRevShareManager(approvedRevShareExtension)
             .getSingleCollaboratorBalance(address(this), collaborator);
 
-        require(amount > 0, "OF:E-011" );
+        require(amount > 0, "OF:E-011");
 
         payable(collaborator).sendValue(amount);
         IRevShareManager(approvedRevShareExtension)


### PR DESCRIPTION
A require statement was missing from the mint function that prevents more than the `maxSupply` being minted. 

- [x] Add `require` statement to `mint()` functions
- [x] Add tests 