### PR TITLE
Fix: Set token sale price to 0 once sale is complete

### DIFF
--- a/contracts/OpenFormat.sol
+++ b/contracts/OpenFormat.sol
@@ -687,6 +687,8 @@ contract OpenFormat is
         // Transfer Payment
         payable(oldOwner).sendValue(tokenSalePrice.sub(amount));
 
+        _setTokenSalePrice(tokenId, 0);
+
         emit Sold(tokenId, oldOwner, newOwner, tokenSalePrice);
 
         _refundOverpayment(tokenSalePrice);


### PR DESCRIPTION
This fix zeros the token sale price to ensure a token can only be sold once each time is it placed on the secondary market.

- [x] Set tokens _tokenSalePrice to 0
- [x] Add tests